### PR TITLE
Fix QApplication header and exec()

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 //#define ARB_DEBUG
 
-#include <QtWidgets/QApplication>
+#include <QApplication>
 #include <DisplayGrid.h>
 #include "MainWindow.h"
 
@@ -17,8 +17,7 @@ int main(int argc, char*argv[]) {
     QApplication app(argc,argv);
     MainWindow mainWindow;
     mainWindow.showMaximized();
-    QApplication::exec();
-    return 0;
+    return app.exec();
 }
 
 /*


### PR DESCRIPTION
- Call exec() with an object rather than class name.
- No need to include QApplication inside QtWidgets.