### PR TITLE
Added toggle feature

### DIFF
--- a/resources/styles/arbalest_simple.qss
+++ b/resources/styles/arbalest_simple.qss
@@ -54,6 +54,8 @@ QLabel {
 
 #toolbarButton:pressed, #minimizeButton:pressed, #maximizeButton:pressed,   #closeButton:pressed    { background-color:"$Color-ButtonPressedMask" ; }
 
+#toolbarButton:checked { background-color: "$Color-ButtonHoverMask"; }
+
 /* Scroll bars ----------------------------------------------------------------------------------------------------*/
 QScrollArea     { border-style: solid; border-width: 0px;   background: transparent;}
 QScrollBar:vertical     {border: none; background-color: transparent; width : 9px;margin: 0px 0 0px 0;}

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -659,9 +659,21 @@ void MainWindow::prepareUi() {
     QToolButton* toggleGrid = new QToolButton(menuTitleBar);
     toggleGrid->setDefaultAction(toggleGridAct);
     toggleGrid->setIcon(QPixmap::fromImage(coloredIcon(":/icons/sharp_grid_on_black_48dp.png", "$Color-IconView")));
-    toggleGrid->setObjectName("toggleGridToolButton");
-    toggleGrid->setToolTip("Toggle grid on/off (G)");
+    toggleGrid->setObjectName("toolbarButton");
+    toggleGrid->setToolTip("Toggle grid on (G)");
     mainTabBarCornerWidget->addWidget(toggleGrid);
+    connect(toggleGrid, &QToolButton::pressed, this, [=]() {
+        if (activeDocumentId == -1) return;
+
+        if (!toggleGrid->isChecked()) {
+            toggleGrid->setChecked(true);
+            toggleGrid->setToolTip("Toggle grid off (G)");
+        }
+        else {
+            toggleGrid->setChecked(false);
+            toggleGrid->setToolTip("Toggle grid on (G)");
+        }
+    });
 
     mainTabBarCornerWidget->addWidget(toolbarSeparator(false));
 


### PR DESCRIPTION
I haven't added color when the tool button remains in a pressed state but added just hover color to the pressed state. I will add the color which will best suit it.
So far what is not working:

- Shotcut Key G can't enable the pressed state of toggle button for Grid Action. But as usual, I can see grids in the window but nothing can be seen on button.
- If I opened a document window and pressed the grid button then it becomes checked state but as soon I close the document window, the button still remains in the checked state. It should go off after I close the document.

For now it looks like after the toggle button is clicked:
<img width="114" alt="Screenshot 2022-06-13 180143" src="https://user-images.githubusercontent.com/16383005/173354286-3c8ac250-0257-4a2c-b64a-a8313d990a4a.png">

I will solve the problems that are currently not working.
