### PR TITLE
Fix OpenGL viewport scaling and build issues on Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,3 +1,8 @@
+cmake_minimum_required(VERSION 3.12)
+
+project(arbalest)
+
+
 find_package(Qt5 COMPONENTS Widgets REQUIRED)
 find_package(OpenGL REQUIRED)
 
@@ -52,6 +57,7 @@ qt5_wrap_cpp(arbalest_PROCESSED_MOCS  ${arbalest_HEADERS_TO_MOC} TARGET arbalest
 qt5_add_resources(arbalest_PROCESSED_RCC resources/resources.qrc)
 
 include_directories(${arbalest_Include_Dirs})
+link_directories(${BRLCAD_INCLUDE_DIRS}/../lib)
 
 add_executable(arbalest
         ${arbalest_Sources}

--- a/src/display/AxesRenderer.cpp
+++ b/src/display/AxesRenderer.cpp
@@ -20,13 +20,20 @@
 /** @file AxesRenderer.cpp */
 
 #if defined(WIN32) && !defined(__CYGWIN__)
-#include<windows.h>
+#  include<windows.h>
 #endif
 
-#include <GL/gl.h>
+#if defined(__APPLE__)
+#  include <OpenGL/gl.h>
+#else
+#  include <GL/gl.h>
+#endif
+
 #include "AxesRenderer.h"
 
+
 #define GRID_LINE_LENGTH 100
+
 
 void AxesRenderer::render() {
     //todo implement line drawing in DisplayManager and use it instead of calling OpenGL here

--- a/src/display/Display.cpp
+++ b/src/display/Display.cpp
@@ -22,6 +22,7 @@
 #include "Display.h"
 
 #include <iostream>
+#include <QScreen>
 #include <QWidget>
 #include <OrthographicCamera.h>
 #include <include/Globals.h>
@@ -76,9 +77,12 @@ DisplayManager* Display::getDisplayManager() const
 }
 
 void Display::resizeGL(const int w, const int h) {
-    camera->setWH(w,h);
-    this->w = w;
-    this->h = h;
+
+    double ratio = QGuiApplication::primaryScreen()->devicePixelRatio();
+
+    camera->setWH(ratio*w,ratio*h);
+    this->w = ratio*w;
+    this->h = ratio*h;
 }
 
 void Display::paintGL() {

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -20,6 +20,7 @@
 /** @file DisplayManager.cpp */
 
 #include <QMatrix4x4>
+#include <QScreen>
 #include "DisplayManager.h"
 
 #define DM_SOLID_LINE 0
@@ -27,6 +28,7 @@
 
 DisplayManager::DisplayManager(Display &display) : display(display)
 {
+  /* FIXME: these curiously crash on Mac */
     setFGColor(0,0,0, 1);
     glLineStipple(1, 0xCF33);
 }
@@ -84,9 +86,11 @@ bool DisplayManager::DrawVListElementCallback::operator()(BRLCAD::VectorList::El
             glPushMatrix();
             glLoadIdentity();
             glTranslated(tlate[0], tlate[1], tlate[2]);
-            /* 96 dpi = 3.78 pixel/mm hardcoded */
-            glScaled(2. * 3.78 / displayManager->display.getW(),
-                     2. * 3.78 / displayManager->display.getH(),
+
+            double dpi = QGuiApplication::primaryScreen()->logicalDotsPerInch();
+
+            glScaled(2. * (dpi / 25.4) / displayManager->display.getW(),
+                     2. * (dpi / 25.4) / displayManager->display.getH(),
                      1.);
             break;
         }

--- a/src/display/GridRenderer.cpp
+++ b/src/display/GridRenderer.cpp
@@ -2,13 +2,20 @@
 #include "GridRenderer.h"
 
 #if defined(WIN32) && !defined(__CYGWIN__)
-#include<windows.h>
+#  include<windows.h>
 #endif
 
-#include <GL/gl.h>
+#if defined(__APPLE__)
+#  include <OpenGL/gl.h>
+#else
+#  include <GL/gl.h>
+#endif
+
 #include <cmath>
 #include <iostream>
+
 #include "AxesRenderer.h"
+
 
 void GridRenderer::render() {
     //todo implement line drawing in DisplayManager and use it instead of calling OpenGL here


### PR DESCRIPTION
This set of changes fixes a couple issues observed on Mac including
finding the OpenGL headers during compilation, quelling cmake
warnings, and most notably, fixing the OpenGL viewport scaling.

Qt's OpenGL contexts have to have the scaling factor accounted for
manually.  Otherwise, they present as an issue on retina displays
where OpenGL only draws in the bottom left quarter of the context.

- need lib dir linking on Mac, and quell cmake
- mac uses framework paths for OpenGL
- fix opengl viewport scaling bug on mac
- update hard-coded dpi to actual
