### PR TITLE
Convert help page to start page

### DIFF
--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -13,6 +13,7 @@ private slots:
     void onLinkClicked(const QString& link);
 signals:
     void ctrlNPressed();
+    void ctrlOPressed();
 };
 
 

--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -11,7 +11,6 @@ public:
     HelpWidget();
 private slots:
     void onLinkClicked(const QString& link);
-    void myCtrlNFunction();
 signals:
     void ctrlNPressed();
 };

--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -6,8 +6,14 @@
 #include "QVBoxWidget.h"
 
 class HelpWidget : public QVBoxWidget{
+    Q_OBJECT
 public:
     HelpWidget();
+private slots:
+    void onLinkClicked(const QString& link);
+    void myCtrlNFunction();
+signals:
+    void ctrlNPressed();
 };
 
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -12,6 +12,7 @@
 #include <QMenuBar>
 #include <QComboBox>
 #include "MouseAction.h"
+#include "HelpWidget.h"
 
 class Document;
 
@@ -21,29 +22,30 @@ class MainWindow : public QMainWindow
     Q_OBJECT
 
 public:
-    MainWindow(QWidget *parent = nullptr);
+    MainWindow(QWidget* parent = nullptr);
     ~MainWindow();
 
-    QStatusBar *getStatusBar() const {
+    QStatusBar* getStatusBar() const {
         return statusBar;
     }
 
     const int statusBarShortMessageDuration = 7000;
 
 private:
-	// UI components
-    Dockable *objectTreeWidgetDockable;
-    Dockable *objectPropertiesDockable;
-    Dockable *toolboxDockable;
-    QStatusBar *statusBar;
+    HelpWidget* helpWidgetInstance;
+    // UI components
+    Dockable* objectTreeWidgetDockable;
+    Dockable* objectPropertiesDockable;
+    Dockable* toolboxDockable;
+    QStatusBar* statusBar;
     QMenuBar* menuTitleBar;
-    QTabWidget *documentArea;
-    QPushButton * maximizeButton;
-    QLabel *statusBarPathLabel;
-    QComboBox * currentViewport;
+    QTabWidget* documentArea;
+    QPushButton* maximizeButton;
+    QLabel* statusBarPathLabel;
+    QComboBox* currentViewport;
     QAction* singleViewAct[4];
-    MouseAction *m_mouseAction;
-	
+    MouseAction* m_mouseAction;
+
     // Stores pointers to all the currently opened documents. Item removed when document is closed. Key is documents ID.
     std::unordered_map<int, Document*> documents;
 
@@ -53,7 +55,7 @@ private:
 
     // The ID of the active document.
     int activeDocumentId = -1;
-	
+
     void prepareUi();
     void loadTheme();
     void prepareDockables();
@@ -61,15 +63,15 @@ private:
     void newFile(); // empty new file
     void openFile(const QString& filePath);
     bool saveFile(const QString& filePath);
-    bool maybeSave(int documentId, bool *cancel = nullptr);
+    bool maybeSave(int documentId, bool* cancel = nullptr);
 
-    QAction *themeAct[2];
-	
+    QAction* themeAct[2];
+
 protected:
-    void changeEvent(QEvent *e) override;
-    bool eventFilter(QObject *watched, QEvent *event) override;
+    void changeEvent(QEvent* e) override;
+    bool eventFilter(QObject* watched, QEvent* event) override;
     void closeEvent(QCloseEvent* event) override;
-	
+
     void moveCameraButtonAction();
     void selectObjectButtonAction();
 
@@ -81,7 +83,7 @@ public slots:
     void saveFileDefaultPath();
     bool saveFileDefaultPathId(int documentId);
     void onActiveDocumentChanged(int newIndex);
-    void tabCloseRequested(int i) ;
+    void tabCloseRequested(int i);
     void objectTreeWidgetSelectionChanged(int objectId);
     void closeButtonPressed();
     void minimizeButtonPressed();

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -32,12 +32,21 @@ public:
     const int statusBarShortMessageDuration = 7000;
 
 private:
+<<<<<<< Updated upstream
     HelpWidget* helpWidgetInstance;
     // UI components
     Dockable* objectTreeWidgetDockable;
     Dockable* objectPropertiesDockable;
     Dockable* toolboxDockable;
     QStatusBar* statusBar;
+=======
+	// UI components
+    HelpWidget* helpWidgetInstance;
+    Dockable *objectTreeWidgetDockable;
+    Dockable *objectPropertiesDockable;
+    Dockable *toolboxDockable;
+    QStatusBar *statusBar;
+>>>>>>> Stashed changes
     QMenuBar* menuTitleBar;
     QTabWidget* documentArea;
     QPushButton* maximizeButton;

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -17,9 +17,9 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     QVBoxWidget *container = new QVBoxWidget();
 
     QString
-    text = "New File  <font style=\"color:$Color-ColorText\">Ctrl+N</font> <br><br>"
-           "Open File  <font style=\"color:$Color-ColorText\">Ctrl+O</font> <br><br>"
-           "Save File  <font style=\"color:$Color-ColorText\">Ctrl+S</font> <br><br>"
+    text = "New File  <a href=\"Ctrl+N\" style=\"color:$Color-ColorText\">Ctrl+N</a> <br><br>"
+           "Open File  <a href=\"Ctrl+O\" style=\"color:$Color-ColorText\">Ctrl+O</a> <br><br>"
+           "Save File  <a href=\"Ctrl+S\" style=\"color:$Color-ColorText\">Ctrl+S</a> <br><br>"
            "<br><br>"
            "Drag with <font style=\"color:$Color-ColorText\">Mouse Left Button</font> to rotate viewport camera<br><br>"
            "Drag with <font style=\"color:$Color-ColorText\">Mouse Right Button</font> to move viewport camera<br><br>"
@@ -46,6 +46,9 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     intro->setOpenExternalLinks(true);
     intro->setMargin(80);
 
+    // Connect the link clicked signal to a slot
+    connect(intro, SIGNAL(linkActivated(QString)), this, SLOT(onLinkClicked(QString)));
+
     container->addWidget(intro);
     QScrollArea * scrollArea = new QScrollArea();
     scrollArea->setObjectName("helpWidget");
@@ -53,4 +56,16 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     scrollArea->setWidget(container);
 
 
+}
+
+void HelpWidget::onLinkClicked(const QString& link) {
+    // Check if the link corresponds to Ctrl+N
+    if (link == "Ctrl+N") {
+        // Call your function for Ctrl+N here
+        myCtrlNFunction();
+    }
+}
+
+void HelpWidget::myCtrlNFunction() {
+    emit ctrlNPressed();
 }

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -43,7 +43,7 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     intro->setObjectName("helpWidget");
     intro->setTextFormat(Qt::RichText);
     intro->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    intro->setOpenExternalLinks(true);
+    intro->setOpenExternalLinks(false);
     intro->setMargin(80);
     intro->setOpenExternalLinks(false);
 
@@ -56,7 +56,16 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     addWidget(scrollArea);
     scrollArea->setWidget(container);
 
+    connect(intro, SIGNAL(linkActivated(QString)), this, SLOT(onLinkClicked(QString)));
+}
 
+void HelpWidget::onLinkClicked(const QString& link) {
+    if (link == "Ctrl+N") {
+        emit ctrlNPressed();
+    }
+    if (link == "Ctrl+O") {
+        emit ctrlOPressed();
+    }
 }
 
 void HelpWidget::onLinkClicked(const QString& link) {

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -19,7 +19,7 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     QString
     text = "New File  <a href=\"Ctrl+N\" style=\"color:$Color-ColorText\">Ctrl+N</a> <br><br>"
            "Open File  <a href=\"Ctrl+O\" style=\"color:$Color-ColorText\">Ctrl+O</a> <br><br>"
-           "Save File  <a href=\"Ctrl+S\" style=\"color:$Color-ColorText\">Ctrl+S</a> <br><br>"
+           "Save File  <font style=\"color:$Color-ColorText\">Ctrl+S</font> <br><br>"
            "<br><br>"
            "Drag with <font style=\"color:$Color-ColorText\">Mouse Left Button</font> to rotate viewport camera<br><br>"
            "Drag with <font style=\"color:$Color-ColorText\">Mouse Right Button</font> to move viewport camera<br><br>"
@@ -45,6 +45,7 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     intro->setTextInteractionFlags(Qt::TextBrowserInteraction);
     intro->setOpenExternalLinks(true);
     intro->setMargin(80);
+    intro->setOpenExternalLinks(false);
 
     // Connect the link clicked signal to a slot
     connect(intro, SIGNAL(linkActivated(QString)), this, SLOT(onLinkClicked(QString)));
@@ -61,6 +62,9 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
 void HelpWidget::onLinkClicked(const QString& link) {
     if (link == "Ctrl+N") {
         emit ctrlNPressed();
+    }
+    if (link == "Ctrl+O") {
+        emit ctrlOPressed();
     }
 }
 

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -59,13 +59,9 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
 }
 
 void HelpWidget::onLinkClicked(const QString& link) {
-    // Check if the link corresponds to Ctrl+N
     if (link == "Ctrl+N") {
-        // Call your function for Ctrl+N here
-        myCtrlNFunction();
+        emit ctrlNPressed();
     }
 }
 
-void HelpWidget::myCtrlNFunction() {
-    emit ctrlNPressed();
-}
+

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -48,6 +48,7 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), m_mouseAction{nul
     }
     Globals::mainWindow = this;
     
+    connect(helpWidgetInstance, &HelpWidget::ctrlNPressed, this, &MainWindow::newFile);
 }
 
 MainWindow::~MainWindow()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -42,12 +42,21 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), m_mouseAction{ nu
     prepareUi();
     prepareDockables();
     helpWidgetInstance = new HelpWidget();
+<<<<<<< Updated upstream
     documentArea->addTab(helpWidgetInstance, "Quick Start"); // Modified this line
     if (QCoreApplication::arguments().length() > 1) {
         openFile(QString(QCoreApplication::arguments().at(1)));
     }
     Globals::mainWindow = this;
 
+=======
+    documentArea->addTab(helpWidgetInstance, "Quick Start");
+    if(QCoreApplication::arguments().length()>1){
+        openFile(QString(QCoreApplication::arguments().at(1)));
+    }
+    Globals::mainWindow = this;
+    
+>>>>>>> Stashed changes
     if (helpWidgetInstance) {
         // Connect the signal to a lambda function for debugging
         connect(helpWidgetInstance, &HelpWidget::ctrlNPressed, this, &MainWindow::newFile);

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -41,14 +41,16 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), m_mouseAction{nul
     loadTheme();
     prepareUi();
     prepareDockables();
-
+    helpWidgetInstance = new HelpWidget();
     documentArea->addTab(new HelpWidget(), "Quick Start");
     if(QCoreApplication::arguments().length()>1){
         openFile(QString(QCoreApplication::arguments().at(1)));
     }
     Globals::mainWindow = this;
     
-    connect(helpWidgetInstance, &HelpWidget::ctrlNPressed, this, &MainWindow::newFile);
+    if (helpWidgetInstance) {
+        connect(helpWidgetInstance, &HelpWidget::ctrlNPressed, this, &MainWindow::newFile);
+    }
 }
 
 MainWindow::~MainWindow()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -36,22 +36,25 @@ using namespace std;
 
 
 
-MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), m_mouseAction{nullptr}
+MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent), m_mouseAction{ nullptr }
 {
     loadTheme();
     prepareUi();
     prepareDockables();
     helpWidgetInstance = new HelpWidget();
-    documentArea->addTab(new HelpWidget(), "Quick Start");
-    if(QCoreApplication::arguments().length()>1){
+    documentArea->addTab(helpWidgetInstance, "Quick Start"); // Modified this line
+    if (QCoreApplication::arguments().length() > 1) {
         openFile(QString(QCoreApplication::arguments().at(1)));
     }
     Globals::mainWindow = this;
-    
+
     if (helpWidgetInstance) {
+        // Connect the signal to a lambda function for debugging
         connect(helpWidgetInstance, &HelpWidget::ctrlNPressed, this, &MainWindow::newFile);
+        connect(helpWidgetInstance, &HelpWidget::ctrlOPressed, this, &MainWindow::openFileDialog);
     }
 }
+
 
 MainWindow::~MainWindow()
 {


### PR DESCRIPTION
While I am trying to implement the feautre where when we click on New File text, it opens a new file.. To make this possible, I define a signal ctrlNPressed in HelpWidget class. When myCtrlNFunction is called, I emit this signal. In MainWindow, I instantiate HelpWidget, connect its signal to newFile function. When Ctrl+N is pressed in HelpWidget, it emits the signal, triggering newFile in MainWindow. This approach ensures communication between classes without tight coupling, enabling modular and maintainable code but It was not working as expected and it is giving an error in the file qobject.h at line number 264. 
The error is "Unhandled exception at 0x00007FFB65CAA9A5 (Qt5Cored.dll) in arbalest.exe: 0xC0000005: Access violation reading location 0xFFFFFFFFFFFFFFFF."