### PR TITLE
Convert help page to start page

### DIFF
--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -12,8 +12,8 @@ public:
 private slots:
     void onLinkClicked(const QString& link);
 signals:
-    void ctrlNPressed();
-    void ctrlOPressed();
+    void ctrlNClicked();
+    void ctrlOClicked();
 };
 
 

--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -8,8 +8,7 @@
 class HelpWidget : public QVBoxWidget{
     Q_OBJECT
 public:
-    HelpWidget();
-    explicit HelpWidget(QWidget* parent = nullptr);
+    explicit HelpWidget(QWidget* parent);
 private slots:
     void onLinkClicked(const QString& link);
 signals:

--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -6,8 +6,14 @@
 #include "QVBoxWidget.h"
 
 class HelpWidget : public QVBoxWidget{
+    Q_OBJECT
 public:
     HelpWidget();
+private slots:
+    void onLinkClicked(const QString& link);
+signals:
+    void ctrlNPressed();
+    void ctrlOPressed();
 };
 
 

--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -8,7 +8,7 @@
 class HelpWidget : public QVBoxWidget{
     Q_OBJECT
 public:
-    explicit HelpWidget(QWidget* parent);
+    HelpWidget(QWidget* parent);
 private slots:
     void onLinkClicked(const QString& link);
 signals:

--- a/include/HelpWidget.h
+++ b/include/HelpWidget.h
@@ -9,6 +9,7 @@ class HelpWidget : public QVBoxWidget{
     Q_OBJECT
 public:
     HelpWidget();
+    explicit HelpWidget(QWidget* parent = nullptr);
 private slots:
     void onLinkClicked(const QString& link);
 signals:

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -12,7 +12,6 @@
 #include <QMenuBar>
 #include <QComboBox>
 #include "MouseAction.h"
-#include "HelpWidget.h"
 
 class Document;
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -60,8 +60,6 @@ private:
     void loadTheme();
     void prepareDockables();
 
-    void newFile(); // empty new file
-    void openFile(const QString& filePath);
     bool saveFile(const QString& filePath);
     bool maybeSave(int documentId, bool *cancel = nullptr);
 
@@ -88,7 +86,8 @@ public slots:
     void closeButtonPressed();
     void minimizeButtonPressed();
     void maximizeButtonPressed();
-
+    void newFile(); // empty new file
+    void openFile(const QString& filePath);
 
 };
 #endif // MAINWINDOW_H

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -12,6 +12,7 @@
 #include <QMenuBar>
 #include <QComboBox>
 #include "MouseAction.h"
+#include "HelpWidget.h"
 
 class Document;
 
@@ -32,6 +33,7 @@ public:
 
 private:
 	// UI components
+    HelpWidget* helpWidgetInstance;
     Dockable *objectTreeWidgetDockable;
     Dockable *objectPropertiesDockable;
     Dockable *toolboxDockable;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -33,7 +33,6 @@ public:
 
 private:
 	// UI components
-    HelpWidget* helpWidget;
     Dockable *objectTreeWidgetDockable;
     Dockable *objectPropertiesDockable;
     Dockable *toolboxDockable;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -33,7 +33,7 @@ public:
 
 private:
 	// UI components
-    HelpWidget* helpWidgetInstance;
+    HelpWidget* helpWidget;
     Dockable *objectTreeWidgetDockable;
     Dockable *objectPropertiesDockable;
     Dockable *toolboxDockable;

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -9,7 +9,6 @@
 #include <iostream>
 #include "HelpWidget.h"
 #include "Globals.h"
-#include "MainWindow.h"
 
 HelpWidget::HelpWidget(QWidget* parent) : QVBoxWidget() {
 

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -55,13 +55,10 @@ HelpWidget::HelpWidget(QWidget* parent) : QVBoxWidget() {
 
     connect(intro, &QLabel::linkActivated, this, &HelpWidget::onLinkClicked);
 
-    if (parent) {
-        MainWindow* mainWindow = qobject_cast<MainWindow*>(parent);
-        if (mainWindow) {
-            connect(this, SIGNAL(ctrlNClicked()), parent, SLOT(newFile()));
-            connect(this, SIGNAL(ctrlOClicked()), parent, SLOT(openFileDialog()));
-        }
-    }
+    
+    connect(this, SIGNAL(ctrlNClicked()), parent, SLOT(newFile()));
+    connect(this, SIGNAL(ctrlOClicked()), parent, SLOT(openFileDialog()));
+    
 
 }
 

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -10,7 +10,7 @@
 #include "HelpWidget.h"
 #include "Globals.h"
 
-HelpWidget::HelpWidget(QWidget* parent) : QVBoxWidget() {
+HelpWidget::HelpWidget(QWidget* parent) : QVBoxWidget(parent) {
 
     setObjectName("helpWidget");
 

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -52,14 +52,14 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     addWidget(scrollArea);
     scrollArea->setWidget(container);
 
-    connect(intro, SIGNAL(linkActivated(QString)), this, SLOT(onLinkClicked(QString)));
+    connect(intro, &QLabel::linkActivated, this, &HelpWidget::onLinkClicked);
 }
 
 void HelpWidget::onLinkClicked(const QString& link) {
     if (link == "Ctrl+N") {
-        emit ctrlNPressed();
+        emit ctrlNClicked();
     }
-    if (link == "Ctrl+O") {
-        emit ctrlOPressed();
+    else if (link == "Ctrl+O") {
+        emit ctrlOClicked();
     }
 }

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -17,8 +17,8 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     QVBoxWidget *container = new QVBoxWidget();
 
     QString
-    text = "New File  <font style=\"color:$Color-ColorText\">Ctrl+N</font> <br><br>"
-           "Open File  <font style=\"color:$Color-ColorText\">Ctrl+O</font> <br><br>"
+    text = "New File  <a href=\"Ctrl+N\" style=\"color:$Color-ColorText\">Ctrl+N</a> <br><br>"
+           "Open File  <a href=\"Ctrl+O\" style=\"color:$Color-ColorText\">Ctrl+O</a> <br><br>"
            "Save File  <font style=\"color:$Color-ColorText\">Ctrl+S</font> <br><br>"
            "<br><br>"
            "Drag with <font style=\"color:$Color-ColorText\">Mouse Left Button</font> to rotate viewport camera<br><br>"
@@ -43,7 +43,7 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     intro->setObjectName("helpWidget");
     intro->setTextFormat(Qt::RichText);
     intro->setTextInteractionFlags(Qt::TextBrowserInteraction);
-    intro->setOpenExternalLinks(true);
+    intro->setOpenExternalLinks(false);
     intro->setMargin(80);
 
     container->addWidget(intro);
@@ -52,5 +52,14 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     addWidget(scrollArea);
     scrollArea->setWidget(container);
 
+    connect(intro, SIGNAL(linkActivated(QString)), this, SLOT(onLinkClicked(QString)));
+}
 
+void HelpWidget::onLinkClicked(const QString& link) {
+    if (link == "Ctrl+N") {
+        emit ctrlNPressed();
+    }
+    if (link == "Ctrl+O") {
+        emit ctrlOPressed();
+    }
 }

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -9,8 +9,9 @@
 #include <iostream>
 #include "HelpWidget.h"
 #include "Globals.h"
+#include "MainWindow.h"
 
-HelpWidget::HelpWidget() : QVBoxWidget() {
+HelpWidget::HelpWidget(QWidget* parent) : QVBoxWidget() {
 
     setObjectName("helpWidget");
 
@@ -53,6 +54,15 @@ HelpWidget::HelpWidget() : QVBoxWidget() {
     scrollArea->setWidget(container);
 
     connect(intro, &QLabel::linkActivated, this, &HelpWidget::onLinkClicked);
+
+    if (parent) {
+        MainWindow* mainWindow = qobject_cast<MainWindow*>(parent);
+        if (mainWindow) {
+            connect(this, &HelpWidget::ctrlNClicked, mainWindow, &MainWindow::newFile);
+            connect(this, &HelpWidget::ctrlOClicked, mainWindow, &MainWindow::openFileDialog);
+        }
+    }
+
 }
 
 void HelpWidget::onLinkClicked(const QString& link) {

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -58,8 +58,8 @@ HelpWidget::HelpWidget(QWidget* parent) : QVBoxWidget() {
     if (parent) {
         MainWindow* mainWindow = qobject_cast<MainWindow*>(parent);
         if (mainWindow) {
-            connect(this, &HelpWidget::ctrlNClicked, mainWindow, &MainWindow::newFile);
-            connect(this, &HelpWidget::ctrlOClicked, mainWindow, &MainWindow::openFileDialog);
+            connect(this, SIGNAL(ctrlNClicked()), parent, SLOT(newFile()));
+            connect(this, SIGNAL(ctrlOClicked()), parent, SLOT(openFileDialog()));
         }
     }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -41,9 +41,8 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), m_mouseAction{nul
     loadTheme();
     prepareUi();
     prepareDockables();
-    helpWidget = new HelpWidget(this);
 
-    documentArea->addTab(helpWidget, "Quick Start");
+    documentArea->addTab(new HelpWidget(this), "Quick Start");
     if(QCoreApplication::arguments().length()>1){
         openFile(QString(QCoreApplication::arguments().at(1)));
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -41,13 +41,19 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), m_mouseAction{nul
     loadTheme();
     prepareUi();
     prepareDockables();
+    helpWidgetInstance = new HelpWidget();
 
-    documentArea->addTab(new HelpWidget(), "Quick Start");
+    documentArea->addTab(helpWidgetInstance, "Quick Start");
     if(QCoreApplication::arguments().length()>1){
         openFile(QString(QCoreApplication::arguments().at(1)));
     }
     Globals::mainWindow = this;
     
+    if (helpWidgetInstance) {
+        // Connect the signal to a lambda function for debugging
+        connect(helpWidgetInstance, &HelpWidget::ctrlNPressed, this, &MainWindow::newFile);
+        connect(helpWidgetInstance, &HelpWidget::ctrlOPressed, this, &MainWindow::openFileDialog);
+    }
 }
 
 MainWindow::~MainWindow()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -41,18 +41,18 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), m_mouseAction{nul
     loadTheme();
     prepareUi();
     prepareDockables();
-    helpWidgetInstance = new HelpWidget();
+    helpWidget = new HelpWidget();
 
-    documentArea->addTab(helpWidgetInstance, "Quick Start");
+    documentArea->addTab(helpWidget, "Quick Start");
     if(QCoreApplication::arguments().length()>1){
         openFile(QString(QCoreApplication::arguments().at(1)));
     }
     Globals::mainWindow = this;
     
-    if (helpWidgetInstance) {
+    if (helpWidget) {
         // Connect the signal to a lambda function for debugging
-        connect(helpWidgetInstance, &HelpWidget::ctrlNPressed, this, &MainWindow::newFile);
-        connect(helpWidgetInstance, &HelpWidget::ctrlOPressed, this, &MainWindow::openFileDialog);
+        connect(helpWidget, &HelpWidget::ctrlNClicked, this, &MainWindow::newFile);
+        connect(helpWidget, &HelpWidget::ctrlOClicked, this, &MainWindow::openFileDialog);
     }
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -41,19 +41,13 @@ MainWindow::MainWindow(QWidget *parent) : QMainWindow(parent), m_mouseAction{nul
     loadTheme();
     prepareUi();
     prepareDockables();
-    helpWidget = new HelpWidget();
+    helpWidget = new HelpWidget(this);
 
     documentArea->addTab(helpWidget, "Quick Start");
     if(QCoreApplication::arguments().length()>1){
         openFile(QString(QCoreApplication::arguments().at(1)));
     }
     Globals::mainWindow = this;
-    
-    if (helpWidget) {
-        // Connect the signal to a lambda function for debugging
-        connect(helpWidget, &HelpWidget::ctrlNClicked, this, &MainWindow::newFile);
-        connect(helpWidget, &HelpWidget::ctrlOClicked, this, &MainWindow::openFileDialog);
-    }
 }
 
 MainWindow::~MainWindow()
@@ -598,7 +592,7 @@ void MainWindow::prepareUi() {
     connect(helpAct, &QAction::triggered, this, [this](){
         HelpWidget * helpWidget = dynamic_cast<HelpWidget*>(documentArea->widget(0));
         if (helpWidget== nullptr){
-            documentArea->insertTab(0,new HelpWidget,"Quick Start");
+            documentArea->insertTab(0,new HelpWidget(this), "Quick Start");
         }
         documentArea->setCurrentIndex(0);
     });

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -14,7 +14,6 @@
 #include <QComboBox>
 #include <include/RaytraceView.h>
 #include <include/AboutWindow.h>
-#include <include/HelpWidget.h>
 #include <brlcad/Database/Arb8.h>
 #include <QtWidgets/QtWidgets>
 #include <brlcad/Database/Torus.h>


### PR DESCRIPTION
I converted the landing page of the Arbalest to the start page by making the text clickable. Now one can create a New File or open an older one by just clicking the Text on the start page. I achieved this functionality by when Ctrl+N or Ctrl+O (text) is pressed in HelpWidget, it emits the signal, triggering newFile or openFile in MainWindow. This approach ensures communication between classes without tight coupling, enabling modular and maintainable code.