### PR TITLE
Select Object feature bug fixed. (When a document is changed, Select object button was not toggling off)

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -87,5 +87,7 @@ public slots:
     void newFile(); // empty new file
     void openFile(const QString& filePath);
 
+signals:
+    void documentChanged();
 };
 #endif // MAINWINDOW_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -408,6 +408,13 @@ void MainWindow::prepareUi() {
             moveCameraButtonAction();
         }
     });
+    connect(this, &MainWindow::documentChanged, this, [=]() {
+        qDebug() << "Received documentChanged signal";
+        selectObjectAct->setChecked(false);
+        if (activeDocumentId != -1) {
+            documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = false;
+        }
+    });
     editMenu->addAction(selectObjectAct);
 
 
@@ -969,6 +976,7 @@ void MainWindow::onActiveDocumentChanged(const int newIndex){
         statusBarPathLabel->setText("");
         activeDocumentId = -1;
     }
+    emit documentChanged();
 }
 
 void MainWindow::tabCloseRequested(const int i)


### PR DESCRIPTION
A signal is emitted whenever document is changed from onActiveDocumentChanged class and it is connected to Select object toggle and its turned off whenever activeDocument is changed.