### PR TITLE
Select Object Document Change bug by changing the activeDocumentId when document is changing

### DIFF
--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -87,5 +87,7 @@ public slots:
     void newFile(); // empty new file
     void openFile(const QString& filePath);
 
+signals:
+    void documentChanged();
 };
 #endif // MAINWINDOW_H

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -401,11 +401,19 @@ void MainWindow::prepareUi() {
             documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = true;
             selectObjectAct->setToolTip("Select Object OFF");
             selectObjectButtonAction();
+            connect(this, &MainWindow::documentChanged, this, [=]() {
+                documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = true;
+                selectObjectButtonAction();
+            });
         }
         else {
             documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = false;
             selectObjectAct->setToolTip("Select Object ON");
             moveCameraButtonAction();
+            connect(this, &MainWindow::documentChanged, this, [=]() {
+                documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = false;
+                moveCameraButtonAction();
+            });
         }
     });
     editMenu->addAction(selectObjectAct);
@@ -969,6 +977,7 @@ void MainWindow::onActiveDocumentChanged(const int newIndex){
         statusBarPathLabel->setText("");
         activeDocumentId = -1;
     }
+    emit documentChanged();
 }
 
 void MainWindow::tabCloseRequested(const int i)

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -395,29 +395,38 @@ void MainWindow::prepareUi() {
         if (activeDocumentId == -1) {
             selectObjectAct->setChecked(false);
             return;
-        }
+        } 
 
         if (documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled == false) {
             documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = true;
             selectObjectAct->setToolTip("Select Object OFF");
             selectObjectButtonAction();
-            connect(this, &MainWindow::documentChanged, this, [=]() {
-                documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = true;
-                selectObjectButtonAction();
-            });
         }
         else {
             documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = false;
             selectObjectAct->setToolTip("Select Object ON");
             moveCameraButtonAction();
-            connect(this, &MainWindow::documentChanged, this, [=]() {
-                documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = false;
-                moveCameraButtonAction();
-            });
         }
     });
-    editMenu->addAction(selectObjectAct);
+    auto updateSelectObjectState = [=]() {
+        if (activeDocumentId == -1) {
+            selectObjectAct->setChecked(false);
+            return;
+        }
 
+        if (selectObjectAct->isChecked()) {
+            documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = true;
+            selectObjectAct->setToolTip("Select Object OFF");
+            selectObjectButtonAction();
+        }
+        else {
+            documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->selectObjectEnabled = false;
+            selectObjectAct->setToolTip("Select Object ON");
+            moveCameraButtonAction();
+        }
+    };
+    connect(selectObjectAct, &QAction::toggled, this, updateSelectObjectState);
+    connect(this, &MainWindow::documentChanged, this, updateSelectObjectState);
 
     QMenu* viewMenu = menuTitleBar->addMenu(tr("&View"));
 


### PR DESCRIPTION
A signal is emited whenever a document is changing and now this signal is catched by selectObjectAct which then allow use the updated document for selectObjectAct. This fixes the bug which was occuring in selectPrimitive feature whenever the document was changing. 