### PR TITLE
Migrated from Qt5.14.2 to Qt6.4.2 and added functionaly to drag MainWindow while it is maximized

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.vscode/
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,7 +6,8 @@ set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 cmake_policy(SET CMP0072 NEW)
 
 find_package(BRLCAD_MOOSE REQUIRED)
-find_package(Qt5 COMPONENTS Widgets REQUIRED)
+find_package(Qt6 COMPONENTS Core Gui Widgets REQUIRED)
+find_package(Qt6 COMPONENTS OpenGLWidgets REQUIRED)
 find_package(OpenGL REQUIRED)
 
 set(arbalest_Include_Dirs
@@ -51,15 +52,18 @@ set(arbalest_Sources
 
 set(arbalest_Link_Libraries
         ${BRLCAD_MOOSE_LIBRARY}
-        Qt5::Widgets
+        Qt6::Core
+        Qt6::Gui
+        Qt6::Widgets
+        Qt6::OpenGLWidgets
         OpenGL::GL)
 
 # Meta-Object Compiling
 file(GLOB arbalest_HEADERS_TO_MOC ./include/*)
-qt5_wrap_cpp(arbalest_PROCESSED_MOCS  ${arbalest_HEADERS_TO_MOC} TARGET arbalest OPTIONS --no-notes)
+qt6_wrap_cpp(arbalest_PROCESSED_MOCS  ${arbalest_HEADERS_TO_MOC} TARGET arbalest OPTIONS --no-notes)
 
 # Resource Compiling
-qt5_add_resources(arbalest_PROCESSED_RCC resources/resources.qrc)
+qt6_add_resources(arbalest_PROCESSED_RCC resources/resources.qrc)
 
 include_directories(${arbalest_Include_Dirs})
 link_directories(${BRLCAD_MOSE_LIBRARY_DIR})

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 The project aims to create a geometry editor for BRL-CAD. The project should ideally be an improvement over the existing editors MGED and Archer.
 
 ## Building
-1. Install and configure Qt. Qt5.14.2 has been used for development of this project.
+1. Install and configure Qt. Qt6.4.2 has been used for development of this project.
 2. Clone BRL-CAD (`git clone https://github.com/BRL-CAD/brlcad.git`), build, and install it
 3. Clone MOOSE (`git clone https://github.com/BRL-CAD/MOOSE.git`), build, and install it
 4. Clone this project (`git clone https://github.com/BRL-CAD/arbalest.git`)

--- a/include/AboutWindow.h
+++ b/include/AboutWindow.h
@@ -1,14 +1,13 @@
-
 #ifndef RT3_ABOUTWINDOW_H
 #define RT3_ABOUTWINDOW_H
 
 
 #include "QVBoxWidget.h"
 
-class AboutWindow : public QVBoxWidget{
+class AboutWindow : public QVBoxWidget
+{
 public:
     AboutWindow();
 };
 
-
-#endif //RT3_ABOUTWINDOW_H
+#endif  //RT3_ABOUTWINDOW_H

--- a/include/ArbDisplay.h
+++ b/include/ArbDisplay.h
@@ -17,7 +17,7 @@
  * License along with this file; see the file named COPYING for more
  * information.
  */
-/** @file Display.h */
+/** @file ArbDisplay.h */
 
 
 #ifndef RT3_DISPLAY_H
@@ -25,28 +25,28 @@
 
 #include <include/Globals.h>
 
-#include <QtWidgets/QOpenGLWidget>
+#include <QOpenGLWidget>
 #include "AxesRenderer.h"
 #include <QMouseEvent>
 #include <include/GridRenderer.h>
 #include "Document.h"
-#include "DisplayManager.h"
+#include "ArbDisplayManager.h"
 #include "OrthographicCamera.h"
 #include "Globals.h"
 #include "QSSPreprocessor.h"
 
 class Document;
-class DisplayManager;
+class ArbDisplayManager;
 class GeometryRenderer;
 class OrthographicCamera;
 class GridRenderer;
 
 
-class Display : public QOpenGLWidget{
+class ArbDisplay : public QOpenGLWidget{
 
 public:
-    Display(Document * document);
-    virtual ~Display();
+    ArbDisplay(Document * document);
+    virtual ~ArbDisplay();
 
     void forceRerenderFrame();
 
@@ -54,7 +54,7 @@ public:
     int getH() const;
     const Document* getDocument() const;
     OrthographicCamera* getCamera() const;
-    DisplayManager* getDisplayManager() const;
+    ArbDisplayManager* getArbDisplayManager() const;
 
     bool gridEnabled = false;
     bool moveCameraEnabled = false;
@@ -73,7 +73,7 @@ private:
     QColor bgColor;
 
     OrthographicCamera  *camera;
-    DisplayManager *displayManager;
+    ArbDisplayManager *displayManager;
     AxesRenderer * axesRenderer;
     GridRenderer * gridRenderer;
 };

--- a/include/ArbDisplayGrid.h
+++ b/include/ArbDisplayGrid.h
@@ -5,40 +5,40 @@
 
 #include <include/QVBoxWidget.h>
 #include <include/Document.h>
-#include <include/Display.h>
+#include <include/ArbDisplay.h>
 #include <QSplitter>
 
-class Display;
+class ArbDisplay;
 class MouseAction;
 
 
-class DisplayGrid : public QVBoxWidget {
+class ArbDisplayGrid : public QVBoxWidget {
 Q_OBJECT
 public:
-    explicit DisplayGrid(Document*  document);
+    explicit ArbDisplayGrid(Document*  document);
 
-    void forceRerenderAllDisplays();
+    void forceRerenderAllArbDisplays();
 
     Document *getDocument()  {
         return document;
     }
 
-    QVector<Display *> &getDisplays() {
+    QVector<ArbDisplay *> &getArbDisplays() {
         return displays;
     }
 
-    Display *getActiveDisplay(){
-        return activeDisplay;
+    ArbDisplay *getActiveArbDisplay(){
+        return activeArbDisplay;
     }
 
-    bool inQuadDisplayMode();
+    bool inQuadArbDisplayMode();
 
-    int getActiveDisplayId();
+    int getActiveArbDisplayId();
 
-    void setActiveDisplay(Display *display);
+    void setActiveArbDisplay(ArbDisplay *display);
 
-    void singleDisplayMode(int displayId);
-    void quadDisplayMode();
+    void singleArbDisplayMode(int displayId);
+    void quadArbDisplayMode();
 
     void resetViewPort(int displayId);
     void resetAllViewPorts();
@@ -47,16 +47,16 @@ public:
     void setSelectObjectMouseAction();
 
 private:
-    double defaultDisplayCameraRotation[4][3] = {
+    double defaultArbDisplayCameraRotation[4][3] = {
             {0, 0, 270},
             {270, 0, 180},
             {270, 0, 270},
             {295, 0, 235}
     };
     Document*  document;
-    QVector<Display *> displays;
+    QVector<ArbDisplay *> displays;
     QVector<MouseAction *> mouseActions;
-    Display *activeDisplay;
+    ArbDisplay *activeArbDisplay;
     QSplitter *verticalSplitter;
     QSplitter *horizontalSplitter1;
     QSplitter *horizontalSplitter2;

--- a/include/ArbDisplayManager.h
+++ b/include/ArbDisplayManager.h
@@ -17,22 +17,22 @@
  * License along with this file; see the file named COPYING for more
  * information.
  */
-/** @file DisplayManager.h */
+/** @file ArbDisplayManager.h */
 
 
-#ifndef RT3_DisplayManager_H
-#define RT3_DisplayManager_H
+#ifndef RT3_ArbDisplayManager_H
+#define RT3_ArbDisplayManager_H
 #ifdef _WIN32
 #include <Windows.h>
 #endif
 
-#include "Display.h"
+#include "ArbDisplay.h"
 #include "brlcad/VectorList.h"
-class Display;
+class ArbDisplay;
 
-class DisplayManager{
+class ArbDisplayManager{
 public:
-    explicit DisplayManager(Display &display);
+    explicit ArbDisplayManager(ArbDisplay &display);
 
     // most of the methods below correspond to a method with a similar name from libdm
     void drawVList(BRLCAD::VectorList *vp);
@@ -63,14 +63,14 @@ public:
             int first = 1;
             int mFlag = 1;
         };
-        const DisplayManager * displayManager;
+        const ArbDisplayManager * displayManager;
         DrawVlistVars * vars;
-        explicit DrawVListElementCallback(const DisplayManager *displayManager, DrawVlistVars *vars);
+        explicit DrawVListElementCallback(const ArbDisplayManager *displayManager, DrawVlistVars *vars);
         bool operator()(BRLCAD::VectorList::Element* element);
     };
 
 private:
-    Display &display;
+    ArbDisplay &display;
 
     int dmLight = 1;
     bool dmTransparency = false;
@@ -87,4 +87,4 @@ private:
 };
 
 
-#endif //RT3_DisplayManager_H
+#endif //RT3_ArbDisplayManager_H

--- a/include/Document.h
+++ b/include/Document.h
@@ -20,7 +20,8 @@ class ArbDisplayGrid;
 class RaytraceView;
 class ObjectTreeWidget;
 
-class Document {
+class Document
+{
 private:
     QString *filePath = nullptr;
     BRLCAD::MemoryDatabase *database;
@@ -43,13 +44,14 @@ public:
     // getters setters
     QString* getFilePath() const
     {
-	    return filePath;
+        return filePath;
     }
 
     RaytraceView * getRaytraceWidget() const
     {
         return raytraceWidget;
     }
+
     BRLCAD::ConstDatabase* getDatabase() const
     {
         return database;
@@ -59,12 +61,12 @@ public:
 
     ObjectTreeWidget* getObjectTreeWidget() const
     {
-	    return objectTreeWidget;
+        return objectTreeWidget;
     }
 
     Properties* getProperties() const
     {
-	    return properties;
+        return properties;
     }
 
     ArbDisplayGrid *getArbDisplayGrid()  {
@@ -73,14 +75,16 @@ public:
 
     int getDocumentId() const
     {
-	    return documentId;
+        return documentId;
     }
 
     ObjectTree* getObjectTree() const
     {
-	    return objectTree;
+        return objectTree;
     }
-    GeometryRenderer *getGeometryRenderer(){
+
+    GeometryRenderer *getGeometryRenderer()
+    {
         return geometryRenderer;
     }
 
@@ -96,5 +100,4 @@ public:
     void getBRLCADObject(const QString& objectName, const std::function<void(BRLCAD::Object&)>& func);
 };
 
-
-#endif //RT3_DOCUMENT_H
+#endif  //RT3_DOCUMENT_H

--- a/include/Document.h
+++ b/include/Document.h
@@ -5,18 +5,18 @@
 #ifndef RT3_DOCUMENT_H
 #define RT3_DOCUMENT_H
 
-#include "Display.h"
+#include "ArbDisplay.h"
 #include "ObjectTree.h"
 #include "ObjectTreeWidget.h"
 #include "Properties.h"
 #include "GeometryRenderer.h"
-#include "DisplayGrid.h"
+#include "ArbDisplayGrid.h"
 #include <include/RaytraceView.h>
 
 class Properties;
-class Display;
+class ArbDisplay;
 class GeometryRenderer;
-class DisplayGrid;
+class ArbDisplayGrid;
 class RaytraceView;
 class ObjectTreeWidget;
 
@@ -24,7 +24,7 @@ class Document {
 private:
     QString *filePath = nullptr;
     BRLCAD::MemoryDatabase *database;
-    DisplayGrid *displayGrid;
+    ArbDisplayGrid *displayGrid;
     ObjectTreeWidget *objectTreeWidget;
     Properties *properties;
     const int documentId;
@@ -55,7 +55,7 @@ public:
         return database;
     }
 
-    Display* getDisplay();
+    ArbDisplay* getArbDisplay();
 
     ObjectTreeWidget* getObjectTreeWidget() const
     {
@@ -67,7 +67,7 @@ public:
 	    return properties;
     }
 
-    DisplayGrid *getDisplayGrid()  {
+    ArbDisplayGrid *getArbDisplayGrid()  {
         return displayGrid;
     }
 

--- a/include/GeometryRenderer.h
+++ b/include/GeometryRenderer.h
@@ -22,7 +22,7 @@
 #ifndef BRLCAD_GEOMETRYRENDERER_H
 #define BRLCAD_GEOMETRYRENDERER_H
 
-#include "DisplayManager.h"
+#include "ArbDisplayManager.h"
 #include "Renderer.h"
 
 class GeometryRenderer:public Renderer {
@@ -30,7 +30,7 @@ public:
 
     explicit GeometryRenderer(Document* document);
 
-    // this is called by Display to render a single frame
+    // this is called by ArbDisplay to render a single frame
     void render() override;
     void refreshForVisibilityAndSolidChanges();
     void clearSolidIfAvailable(int objectId);
@@ -44,10 +44,10 @@ private:
     void drawSolid(int objectId);
 
     // Contains generated display list alone with corresponding objectId. objectId is the key. displayListId is value.
-    QHash<int, int>             objectIdDisplayListIdMap;
+    QHash<int, int>             objectIdArbDisplayListIdMap;
 
-    QVector<int> visibleDisplayListIds;
-    QVector<int> objectsToBeDisplayedIds;
+    QVector<int> visibleArbDisplayListIds;
+    QVector<int> objectsToBeArbDisplayedIds;
 };
 
 

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -1,7 +1,7 @@
 #ifndef GLOBALS_H
 #define GLOBALS_H
 
-#include "Display.h"
+#include "ArbDisplay.h"
 
 class MainWindow;
 class QSSPreprocessor;

--- a/include/Globals.h
+++ b/include/Globals.h
@@ -6,11 +6,11 @@
 class MainWindow;
 class QSSPreprocessor;
 
-class Globals{
+class Globals
+{
 public:
     static QSSPreprocessor *theme;
     static MainWindow *mainWindow;
 };
 
-
-#endif
+#endif  // GLOBALS_H

--- a/include/GridRenderer.h
+++ b/include/GridRenderer.h
@@ -4,19 +4,19 @@
 
 
 #include "Renderer.h"
-#include "Display.h"
+#include "ArbDisplay.h"
 
-class Display;
+class ArbDisplay;
 
 class GridRenderer: public Renderer {
 
 public:
     void render() override;
 
-    GridRenderer(Display *display);
+    GridRenderer(ArbDisplay *display);
 
 private:
-    Display * display;
+    ArbDisplay * display;
 };
 
 

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -36,8 +36,11 @@ private:
     Dockable *toolboxDockable;
     QStatusBar *statusBar;
     QMenuBar* menuTitleBar;
+    QPushButton *applicationIcon;
+    QPushButton *minimizeButton;
+    QPushButton *maximizeButton;
+    QPushButton *closeButton;
     QTabWidget *documentArea;
-    QPushButton * maximizeButton;
     QLabel *statusBarPathLabel;
     QComboBox * currentViewport;
     QAction* singleViewAct[4];
@@ -50,9 +53,11 @@ private:
     // Total number of documents ever opened in application's life time. This is not decreased when closing documents.
     // A document's ID is set to documentsCount at the moment of opening it.
     int documentsCount = 0;
-
     // The ID of the active document.
     int activeDocumentId = -1;
+
+    // Number of menus open in the MENU BAR
+    int nMenusOpen = 0;
     
     void loadTheme();
     // Prepares MENU BAR, STATUS BAR and DOCUMENT AREA
@@ -92,6 +97,8 @@ public slots:
     void minimizeButtonPressed();
     void maximizeButtonPressed();
     void updateMouseButtonObjectState();
+    void increaseMenusOpen();
+    void decreaseMenusOpen();
 };
 
 #endif  // MAINWINDOW_H

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -15,7 +15,6 @@
 
 class Document;
 
-
 class MainWindow : public QMainWindow
 {
     Q_OBJECT
@@ -31,7 +30,7 @@ public:
     const int statusBarShortMessageDuration = 7000;
 
 private:
-	// UI components
+    // UI components
     Dockable *objectTreeWidgetDockable;
     Dockable *objectPropertiesDockable;
     Dockable *toolboxDockable;
@@ -44,7 +43,7 @@ private:
     QAction* singleViewAct[4];
     MouseAction *m_mouseAction;
     QAction* selectObjectAct;
-	
+    
     // Stores pointers to all the currently opened documents. Item removed when document is closed. Key is documents ID.
     std::unordered_map<int, Document*> documents;
 
@@ -54,27 +53,34 @@ private:
 
     // The ID of the active document.
     int activeDocumentId = -1;
-	
-    void prepareUi();
+    
     void loadTheme();
+    // Prepares MENU BAR, STATUS BAR and DOCUMENT AREA
+    void prepareUi();
+    // Prepares OBJECTS SIDE MENU and PROPERTIES SIDE MENU
     void prepareDockables();
 
     bool saveFile(const QString& filePath);
     bool maybeSave(int documentId, bool *cancel = nullptr);
 
     QAction *themeAct[2];
-	
+    
 protected:
-    void changeEvent(QEvent *e) override;
+    // Drag MAIN WINDOW by holding from MENU BAR (now functioning as title bar too)
     bool eventFilter(QObject *watched, QEvent *event) override;
+    void changeEvent(QEvent *e) override;
     void closeEvent(QCloseEvent* event) override;
-	
+    
     void moveCameraButtonAction();
     void selectObjectButtonAction();
 
 public slots:
-    void openFileDialog();
+    // New empty file
+    void newFile();
+    // Open file
+    void openFile(const QString& filePath);
     bool saveFileId(const QString& filePath, int documentId);
+    void openFileDialog();
     void saveAsFileDialog();
     bool saveAsFileDialogId(int documentId);
     void saveFileDefaultPath();
@@ -85,8 +91,7 @@ public slots:
     void closeButtonPressed();
     void minimizeButtonPressed();
     void maximizeButtonPressed();
-    void newFile(); // empty new file
-    void openFile(const QString& filePath);
     void updateMouseButtonObjectState();
 };
-#endif // MAINWINDOW_H
+
+#endif  // MAINWINDOW_H

--- a/include/MouseAction.h
+++ b/include/MouseAction.h
@@ -24,8 +24,8 @@
 
 #include <QObject>
 
-class Display;
-class DisplayGrid;
+class ArbDisplay;
+class ArbDisplayGrid;
 
 
 class MouseAction : public QObject
@@ -35,10 +35,10 @@ public:
     virtual ~MouseAction();
 
 protected:
-    DisplayGrid* m_parent;
-    Display*     m_watched;
+    ArbDisplayGrid* m_parent;
+    ArbDisplay*     m_watched;
 
-    explicit MouseAction(DisplayGrid* parent = nullptr, Display* watched = nullptr);
+    explicit MouseAction(ArbDisplayGrid* parent = nullptr, ArbDisplay* watched = nullptr);
 
 signals:
     void Done(MouseAction* myself);

--- a/include/MoveCameraMouseAction.h
+++ b/include/MoveCameraMouseAction.h
@@ -28,7 +28,7 @@
 class MoveCameraMouseAction : public MouseAction
 {
 public:
-    explicit MoveCameraMouseAction(DisplayGrid* parent = nullptr, Display* watched = nullptr);
+    explicit MoveCameraMouseAction(ArbDisplayGrid* parent = nullptr, ArbDisplay* watched = nullptr);
     virtual ~MoveCameraMouseAction();
 
 protected:

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -1,4 +1,3 @@
-
 #ifndef RT3_OBJECTTREE_H
 #define RT3_OBJECTTREE_H
 
@@ -10,7 +9,6 @@
 #include <brlcad/Database/Combination.h>
 #include <functional>
 #include <set>
-
 
 #include "Utils.h"
 
@@ -27,9 +25,10 @@
  * multiple times in the tree like all.g\orb and ball.g\orb
  */
 
-class ObjectTree {
+class ObjectTree
+{
 public:
-    enum VisibilityState{
+    enum VisibilityState {
         Invisible,
         SomeChildrenVisible,
         FullyVisible,
@@ -45,10 +44,10 @@ public:
     void buildColorMap(int rootObjectId);
     int addTopObject(QString name);
 
-        // getters
+    // getters
     BRLCAD::MemoryDatabase* getDatabase() const
     {
-	    return database;
+        return database;
     }
 
     QHash<int, QVector<int>>& getChildren()
@@ -70,7 +69,7 @@ public:
     {
         return fullPathMap;
     }
-	
+    
     QHash<int, ColorInfo>& getColorMap()
     {
         return colorMap;
@@ -84,11 +83,11 @@ public:
     QHash<int, VisibilityState> &getObjectVisibility() {
         return objectIdVisibilityStateMap;
     }
-	
+    
 private:
     BRLCAD::MemoryDatabase* database;
-	
-	// this class is used for traversing the MemoryDatabase and produce the tree
+    
+    // this class is used for traversing the MemoryDatabase and produce the tree
     class ObjectTreeCallback {
     public:
         ObjectTreeCallback(ObjectTree* objectTree, QString& objectName, const int& parentObjectId) :
@@ -102,31 +101,31 @@ private:
         ObjectTree* objectTree = nullptr;
         QString objectName;
         const int& parentObjectId;
-    	QString currentObjectPath;
+        QString currentObjectPath;
         QVector<int>* childrenNames = nullptr;
         void traverseSubTree(const BRLCAD::Combination::ConstTreeNode& node) const; //traverse the boolean tree of the MemoryDatabase
     };
 
     // Stores the object tree in  {parent's object id (key), children's object ids (value)} format
-    QHash<int, QVector<int>>    objectIdChildrenObjectIdsMap;
+    QHash<int, QVector<int>>     objectIdChildrenObjectIdsMap;
 
     // Stores the object tree in  { object id (key), parent's object id (value)} format
-    QHash<int, int>    objectIdParentObjectIdMap;
+    QHash<int, int>              objectIdParentObjectIdMap;
 
-	// Object id to it's name mapping
-    QHash<int, QString>         nameMap;
-
-    // Object id to it's full path mapping
-    QHash<int, QString>         fullPathMap;
+    // Object id to it's name mapping
+    QHash<int, QString>          nameMap;
 
     // Object id to it's full path mapping
-    QHash<int, ColorInfo>         colorMap;
+    QHash<int, QString>          fullPathMap;
+
+    // Object id to it's full path mapping
+    QHash<int, ColorInfo>        colorMap;
 
     // Get all objects that are not combinations. (ie. these are also the objects that can be drawn) //todo _GLOBAL?
-    QSet<int>                   drawableObjectIds;
+    QSet<int>                    drawableObjectIds;
 
 
-    QHash<int, VisibilityState>             objectIdVisibilityStateMap;
+    QHash<int, VisibilityState>  objectIdVisibilityStateMap;
 };
 
-#endif
+#endif  // RT3_OBJECTTREE_H

--- a/include/OrthographicCamera.h
+++ b/include/OrthographicCamera.h
@@ -48,7 +48,7 @@ private:
     float verticalSpan = 600;
 
     QVector3D angleAroundAxes = initialAngleAroundAxes; // Camera direction in degrees
-    float w = 400, h = 400;         // Display width and height.
+    float w = 400, h = 400;         // ArbDisplay width and height.
 
 public:
     explicit OrthographicCamera(Document * document) : document(document){}

--- a/include/PerspectiveCamera.h
+++ b/include/PerspectiveCamera.h
@@ -20,11 +20,11 @@ private:
     const float eyeRotationPerMouseDelta = 60.f;
     const float eyeMovementPerWheelAngle = .1f;
     const int mouseMaxDrag = 500;
-    const float fov = 60; // Field of view (angle from Display bottom to top) in degrees
+    const float fov = 60; // Field of view (angle from ArbDisplay bottom to top) in degrees
 
     QVector3D angleAroundAxes = initialAngleAroundAxes; // Camera direction in degrees
     QVector3D eyePosition = initialEyePosition; // Camera coordinates
-    float w = 400, h = 400;         // Display width and height.
+    float w = 400, h = 400;         // ArbDisplay width and height.
 
 public:
     PerspectiveCamera();

--- a/include/SelectMouseAction.h
+++ b/include/SelectMouseAction.h
@@ -27,9 +27,9 @@
 class SelectMouseAction : public MouseAction
 {
 public:
-    explicit SelectMouseAction(DisplayGrid* parent = nullptr, Display* watched = nullptr);
+    explicit SelectMouseAction(ArbDisplayGrid* parent = nullptr, ArbDisplay* watched = nullptr);
     virtual ~SelectMouseAction();
-    void Deselect(Display* m_watched);
+    void Deselect(ArbDisplay* m_watched);
 
     QString getSelected() const;
 

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -11,6 +11,7 @@
 #include <chrono>
 #include <stack>
 #include <iostream>
+
 using namespace std::chrono;
 using namespace std;
 
@@ -26,18 +27,17 @@ struct ColorInfo {
     float red, green, blue;
     bool hasColor;
 
-    QColor toQColor() const{
-        return QColor(red*255,green*255,blue*255);
+    QColor toQColor() const {
+        return QColor(red*255, green*255, blue*255);
     }
 
-    QString toHexString() const{
+    QString toHexString() const {
         return toQColor().name(QColor::HexRgb);
     }
 };
 
 const double * getLeafMatrix(BRLCAD::Combination::ConstTreeNode& node, const QString& name);
 void setLeafMatrix(BRLCAD::Combination::TreeNode& node, const QString& name, double * matrix);
-
 
 template<typename T>
 inline void addPropertiesTitle(T* l, const QString &title, const QString indexText = "") {
@@ -55,8 +55,7 @@ inline void addPropertiesTitle(T* l, const QString &title, const QString indexTe
             hbox->addWidget(titleWidget);
             l->addWidget(hbox);
             hbox->getBoxLayout()->addStretch();
-        }
-        else{
+        } else {
             QLabel *titleWidget = new QLabel(title);
             titleWidget->setMargin(2);
             l->addWidget(titleWidget);
@@ -64,13 +63,12 @@ inline void addPropertiesTitle(T* l, const QString &title, const QString indexTe
     }
 }
 
-inline QWidget * toolbarSeparator(bool horizontal){
+inline QWidget * toolbarSeparator(bool horizontal) {
     QWidget *widget = new QWidget;
-    if(horizontal){
+    if(horizontal) {
         widget->setFixedHeight(1);
         widget->setSizePolicy(QSizePolicy::Expanding,QSizePolicy::Fixed);
-    }
-    else {
+    } else {
         widget->setFixedWidth(1);
         widget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
     }
@@ -82,12 +80,12 @@ QImage coloredIcon(QString path, QString colorKey = "");
 
 static std::stack <time_point<high_resolution_clock>> times;
 static std::stack <QString> timerNames;
-inline void ts(QString name = "Timer"){
+inline void ts(QString name = "Timer") {
     times.push(high_resolution_clock::now());
     timerNames.push(name);
 }
 
-inline void te(){
+inline void te() {
     time_point<high_resolution_clock> startTime = times.top();
 
     milliseconds duration = duration_cast<milliseconds>( high_resolution_clock::now()-startTime);
@@ -98,5 +96,4 @@ inline void te(){
 class Document;
 bool getObjectNameFromUser(QWidget* parent, Document& document, QString& name);
 
-
-#endif // UTILS_ARBALEST_H
+#endif  // UTILS_ARBALEST_H

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -3,18 +3,16 @@
 //
 
 #include <Document.h>
-#include<ArbDisplay.h>
+#include <ArbDisplay.h>
 #include <brlcad/Database/Torus.h>
 
 
-Document::Document(const int documentId, const QString *filePath) : documentId(documentId) {
+Document::Document(const int documentId, const QString *filePath) : documentId(documentId)
+{
     if (filePath != nullptr) this->filePath = new QString(*filePath);
     database =  new BRLCAD::MemoryDatabase();
     if (filePath != nullptr) {
-        if (!database->Load(filePath->toUtf8().data()))
-        {
-            throw std::runtime_error("Failed to open file");
-        }
+        if (!database->Load(filePath->toUtf8().data())) throw std::runtime_error("Failed to open file");
     }
 
     modified = false;
@@ -29,45 +27,48 @@ Document::Document(const int documentId, const QString *filePath) : documentId(d
     raytraceWidget = new RaytraceView(this);
 }
 
-Document::~Document() {
+Document::~Document()
+{
     delete database;
 }
 
-void Document::modifyObject(BRLCAD::Object *newObject) {
+void Document::modifyObject(BRLCAD::Object *newObject)
+{
     modified = true;
     database->Set(*newObject);
     QString objectName = newObject->Name();
-    getObjectTree()->traverseSubTree(0,false,[this, objectName]
-    (int objectId){
-        if (getObjectTree()->getNameMap()[objectId] == objectName){
-            geometryRenderer->clearObject(objectId);
-        }
+    getObjectTree()->traverseSubTree(0,false,[this, objectName](int objectId) {
+        if (getObjectTree()->getNameMap()[objectId] == objectName) geometryRenderer->clearObject(objectId);
         return true;
-    }
-    );
+    });
     geometryRenderer->refreshForVisibilityAndSolidChanges();
     for (ArbDisplay * display : displayGrid->getArbDisplays())display->forceRerenderFrame();
 }
 
-bool Document::isModified() {
+bool Document::isModified()
+{
     return modified;
 }
 
-bool Document::Add(const BRLCAD::Object& object) {
+bool Document::Add(const BRLCAD::Object& object)
+{
     modified = true;
     return database->Add(object);
 }
 
-bool Document::Save(const char* fileName) {
+bool Document::Save(const char* fileName)
+{
     modified = false;
     return database->Save(fileName);
 }
 
-void Document::getBRLCADConstObject(const QString& objectName, const std::function<void(const BRLCAD::Object&)>& func) const {
+void Document::getBRLCADConstObject(const QString& objectName, const std::function<void(const BRLCAD::Object&)>& func) const
+{
     database->Get(objectName.toUtf8(), [func](const BRLCAD::Object& object){func(object);});
 }
 
-void Document::getBRLCADObject(const QString& objectName, const std::function<void(BRLCAD::Object&)>& func) {
+void Document::getBRLCADObject(const QString& objectName, const std::function<void(BRLCAD::Object&)>& func)
+{
     database->Get(objectName.toUtf8(), func);
     modified = true;
 }

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -3,7 +3,7 @@
 //
 
 #include <Document.h>
-#include<Display.h>
+#include<ArbDisplay.h>
 #include <brlcad/Database/Torus.h>
 
 
@@ -22,9 +22,9 @@ Document::Document(const int documentId, const QString *filePath) : documentId(d
     properties = new Properties(*this);
     geometryRenderer = new GeometryRenderer(this);
     objectTreeWidget = new ObjectTreeWidget(this);
-    displayGrid = new DisplayGrid(this);
+    displayGrid = new ArbDisplayGrid(this);
 
-    displayGrid->forceRerenderAllDisplays();
+    displayGrid->forceRerenderAllArbDisplays();
 
     raytraceWidget = new RaytraceView(this);
 }
@@ -46,7 +46,7 @@ void Document::modifyObject(BRLCAD::Object *newObject) {
     }
     );
     geometryRenderer->refreshForVisibilityAndSolidChanges();
-    for (Display * display : displayGrid->getDisplays())display->forceRerenderFrame();
+    for (ArbDisplay * display : displayGrid->getArbDisplays())display->forceRerenderFrame();
 }
 
 bool Document::isModified() {
@@ -72,7 +72,7 @@ void Document::getBRLCADObject(const QString& objectName, const std::function<vo
     modified = true;
 }
 
-Display* Document::getDisplay()
+ArbDisplay* Document::getArbDisplay()
 {
-    return displayGrid->getActiveDisplay();
+    return displayGrid->getActiveArbDisplay();
 }

--- a/src/Globals.cpp
+++ b/src/Globals.cpp
@@ -1,4 +1,3 @@
-
 #include <Globals.h>
 
 QSSPreprocessor *Globals::theme;

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -34,102 +34,95 @@
 
 void ObjectTree::ObjectTreeCallback::operator()(const BRLCAD::Object& object)
 {
-	objectId = ++objectTree->lastAllocatedId;
+    objectId = ++objectTree->lastAllocatedId;
     objectTree->getChildren()[objectId] = QVector<int>();
-	objectTree->objectIdParentObjectIdMap[objectId] = parentObjectId;
-	childrenNames = &objectTree->getChildren()[objectId];
+    objectTree->objectIdParentObjectIdMap[objectId] = parentObjectId;
+    childrenNames = &objectTree->getChildren()[objectId];
 
-	objectTree->getFullPathMap()[objectId] = currentObjectPath;
+    objectTree->getFullPathMap()[objectId] = currentObjectPath;
 
-
-	if (const BRLCAD::Combination* combination = dynamic_cast<const BRLCAD::Combination*>(&object)) {
-
-		traverseSubTree(combination->Tree());
-	}
-	else
-	{
-		objectTree->getDrawableObjectIds().insert(objectId);
-	}
+    if (const BRLCAD::Combination* combination = dynamic_cast<const BRLCAD::Combination*>(&object)) {
+        traverseSubTree(combination->Tree());
+    } else {
+        objectTree->getDrawableObjectIds().insert(objectId);
+    }
 }
 
 void ObjectTree::ObjectTreeCallback::traverseSubTree(const BRLCAD::Combination::ConstTreeNode& node) const
 {
-	switch (node.Operation())
-	{
-	case BRLCAD::Combination::ConstTreeNode::Union:
-	case BRLCAD::Combination::ConstTreeNode::Intersection:
-	case BRLCAD::Combination::ConstTreeNode::Subtraction:
-	case BRLCAD::Combination::ConstTreeNode::ExclusiveOr:
-		traverseSubTree(node.LeftOperand());
-		traverseSubTree(node.RightOperand());
-		break;
+    switch (node.Operation()) {
+        case BRLCAD::Combination::ConstTreeNode::Union:
+        case BRLCAD::Combination::ConstTreeNode::Intersection:
+        case BRLCAD::Combination::ConstTreeNode::Subtraction:
+        case BRLCAD::Combination::ConstTreeNode::ExclusiveOr:
+            traverseSubTree(node.LeftOperand());
+            traverseSubTree(node.RightOperand());
+            break;
+        
+        case BRLCAD::Combination::ConstTreeNode::Not:
+            traverseSubTree(node.Operand());
+            break;
 
-	case BRLCAD::Combination::ConstTreeNode::Not:
-		traverseSubTree(node.Operand());
-		break;
-
-	case BRLCAD::Combination::ConstTreeNode::Leaf:
-        objectTree->getChildren()[objectId].append(objectTree->lastAllocatedId + 1);
-		QString childName = QString(node.Name());
-		objectTree->getNameMap()[objectTree->lastAllocatedId + 1] = childName;
-		ObjectTreeCallback callback(objectTree, childName, objectId);
-		objectTree->getDatabase()->Get(node.Name(), callback);
-	}
+        case BRLCAD::Combination::ConstTreeNode::Leaf:
+            objectTree->getChildren()[objectId].append(objectTree->lastAllocatedId + 1);
+            QString childName = QString(node.Name());
+            objectTree->getNameMap()[objectTree->lastAllocatedId + 1] = childName;
+            ObjectTreeCallback callback(objectTree, childName, objectId);
+            objectTree->getDatabase()->Get(node.Name(), callback);
+    }
 }
 
-
-int ObjectTree::addTopObject(QString name) {
-	QVector<int>* childrenNames = &getChildren()[0];
+int ObjectTree::addTopObject(QString name)
+{
+    QVector<int>* childrenNames = &getChildren()[0];
     int topObjectId = lastAllocatedId + 1;
-	childrenNames->append(topObjectId);
-	getNameMap()[topObjectId] = name;
-	ObjectTreeCallback callback(this, name, 0);
-	database->Get(name.toUtf8(), callback);
+    childrenNames->append(topObjectId);
+    getNameMap()[topObjectId] = name;
+    ObjectTreeCallback callback(this, name, 0);
+    database->Get(name.toUtf8(), callback);
     buildColorMap(topObjectId);
-	return topObjectId;
+    return topObjectId;
 }
 
-
-ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database) : database(database) {
-	BRLCAD::ConstDatabase::TopObjectIterator it = database->FirstTopObject();
+ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database) : database(database)
+{
+    BRLCAD::ConstDatabase::TopObjectIterator it = database->FirstTopObject();
 
     objectIdChildrenObjectIdsMap[0] = QVector<int>(); // objectId of root is 0
     objectIdParentObjectIdMap[0] = -1;
-	nameMap[0] = "";
-	colorMap[0] = {1,1,1,false };
+    nameMap[0] = "";
+    colorMap[0] = {1,1,1,false };
 
-
-	while (it.Good()) {
-		QString childName = it.Name();
-		addTopObject(childName);
-		++it;
-	}
-
+    while (it.Good()) {
+        QString childName = it.Name();
+        addTopObject(childName);
+        ++it;
+    }
 }
 
 void ObjectTree::traverseSubTree(const int rootOfSubTreeId, bool traverseRoot, const std::function<bool(int)>& callback)
 {
-	if(traverseRoot) callback(rootOfSubTreeId);
-	for (int objectId : objectIdChildrenObjectIdsMap[rootOfSubTreeId]) {
-		if (!callback(objectId)) continue;
-		if (objectIdChildrenObjectIdsMap.contains(rootOfSubTreeId)) traverseSubTree(objectId, false, callback);
-	}
+    if(traverseRoot) callback(rootOfSubTreeId);
+    for (int objectId : objectIdChildrenObjectIdsMap[rootOfSubTreeId]) {
+        if (!callback(objectId)) continue;
+        if (objectIdChildrenObjectIdsMap.contains(rootOfSubTreeId)) traverseSubTree(objectId, false, callback);
+    }
 }
 
-
-void ObjectTree::changeVisibilityState(int objectId, bool visible) {
-    if (visible){
+void ObjectTree::changeVisibilityState(int objectId, bool visible)
+{
+    if (visible) {
         objectIdVisibilityStateMap[objectId] = FullyVisible;
 
         // First we go up in the tree and make necessary changes
         int ancestorId = getParent()[objectId];
-        while (ancestorId != -1){
+        while (ancestorId != -1) {
             // if all children of the ancestor are fully visible after the change ancestor's visibility should be FullyVisible
             objectIdVisibilityStateMap[ancestorId] = FullyVisible;
 
             // but if there is a not fully visible child it should be SomeChildrenVisible
-            for (int ancestorChildId : getChildren()[ancestorId]){
-                if (objectIdVisibilityStateMap[ancestorChildId] != FullyVisible){
+            for (int ancestorChildId : getChildren()[ancestorId]) {
+                if (objectIdVisibilityStateMap[ancestorChildId] != FullyVisible) {
                     objectIdVisibilityStateMap[ancestorId] = SomeChildrenVisible;
                 }
             }
@@ -137,24 +130,22 @@ void ObjectTree::changeVisibilityState(int objectId, bool visible) {
         }
 
         // All children of objectId should be fully visible
-        traverseSubTree(objectId, false,[this] (int childId){
+        traverseSubTree(objectId, false,[this] (int childId) {
             objectIdVisibilityStateMap[childId] = FullyVisible;
             return true;
         });
-    }
-
-    else{
+    } else {
         objectIdVisibilityStateMap[objectId] = Invisible;
 
         // First we go up in the tree and make necessary changes
         int ancestorId = getParent()[objectId];
-        while (ancestorId != -1){
+        while (ancestorId != -1) {
             // if all children of the ancestor are invisible after the change ancestor's visibility should be Invisible
             objectIdVisibilityStateMap[ancestorId] = Invisible;
 
             // but if there is a not fully visible child it should be SomeChildrenVisible
-            for (int ancestorChildId : getChildren()[ancestorId]){
-                if (objectIdVisibilityStateMap[ancestorChildId] != Invisible){
+            for (int ancestorChildId : getChildren()[ancestorId]) {
+                if (objectIdVisibilityStateMap[ancestorChildId] != Invisible) {
                     objectIdVisibilityStateMap[ancestorId] = SomeChildrenVisible;
                 }
             }
@@ -162,28 +153,29 @@ void ObjectTree::changeVisibilityState(int objectId, bool visible) {
         }
 
         // All children of objectId should be invisible
-        traverseSubTree(objectId, false,[this] (int childId){
+        traverseSubTree(objectId, false,[this] (int childId) {
             objectIdVisibilityStateMap[childId] = Invisible;
             return true;
         });
     }
 }
 
-void ObjectTree::buildColorMap(int rootObjectId) {
-	traverseSubTree(rootObjectId,true,[&](int objectId){
-		if(objectId==0)return true;
-		const QString objectName = fullPathMap[objectId];
-		const QByteArray &name = objectName.toUtf8();
-		BRLCAD::Object *object = database->Get(name);
-		colorMap[objectId] = ColorInfo(colorMap[objectIdParentObjectIdMap[objectId]]);
-		if(const BRLCAD::Combination* combination = dynamic_cast<const BRLCAD::Combination*>(object)) {
-			if (combination->HasColor()) {
-				colorMap[objectId].red = combination->Red();
-				colorMap[objectId].green = combination->Green();
-				colorMap[objectId].blue = combination->Blue();
-				colorMap[objectId].hasColor = true;
-			}
-		}
-		return true;
-	});
+void ObjectTree::buildColorMap(int rootObjectId)
+{
+    traverseSubTree(rootObjectId,true,[&](int objectId) {
+        if(objectId==0) return true;
+        const QString objectName = fullPathMap[objectId];
+        const QByteArray &name = objectName.toUtf8();
+        BRLCAD::Object *object = database->Get(name);
+        colorMap[objectId] = ColorInfo(colorMap[objectIdParentObjectIdMap[objectId]]);
+        if(const BRLCAD::Combination* combination = dynamic_cast<const BRLCAD::Combination*>(object)) {
+            if (combination->HasColor()) {
+                colorMap[objectId].red = combination->Red();
+                colorMap[objectId].green = combination->Green();
+                colorMap[objectId].blue = combination->Blue();
+                colorMap[objectId].hasColor = true;
+            }
+        }
+        return true;
+    });
 }

--- a/src/display/AxesRenderer.cpp
+++ b/src/display/AxesRenderer.cpp
@@ -36,7 +36,7 @@
 
 
 void AxesRenderer::render() {
-    //todo implement line drawing in DisplayManager and use it instead of calling OpenGL here
+    //todo implement line drawing in ArbDisplayManager and use it instead of calling OpenGL here
     glBegin(GL_LINES);
     glColor3f(0,1,0);
     glVertex3f(0, GRID_LINE_LENGTH, 0);

--- a/src/display/Display.cpp
+++ b/src/display/Display.cpp
@@ -17,26 +17,26 @@
  * License along with this file; see the file named COPYING for more
  * information.
  */
-/** @file Display.cpp */
+/** @file ArbDisplay.cpp */
 
-#include "Display.h"
+#include "ArbDisplay.h"
 
 #include <iostream>
 #include <QScreen>
 #include <QWidget>
 #include <OrthographicCamera.h>
 #include <include/Globals.h>
-#include "DisplayManager.h"
+#include "ArbDisplayManager.h"
 #include "GeometryRenderer.h"
 #include "Utils.h"
 
 using namespace std;
 
 
-Display::Display(Document*  document)
+ArbDisplay::ArbDisplay(Document*  document)
     :document(document) {
     camera = new OrthographicCamera(document);
-    displayManager = new DisplayManager(*this);
+    displayManager = new ArbDisplayManager(*this);
     axesRenderer = new AxesRenderer();
     gridRenderer = new GridRenderer(this);
 
@@ -47,37 +47,37 @@ Display::Display(Document*  document)
     update();
 }
 
-Display::~Display() {
+ArbDisplay::~ArbDisplay() {
     delete camera;
     delete displayManager;
     delete axesRenderer;
 }
 
 
-void Display::forceRerenderFrame() {
+void ArbDisplay::forceRerenderFrame() {
     makeCurrent();
     update();
 }
 
-int Display::getW() const {
+int ArbDisplay::getW() const {
     return w;
 }
 
-int Display::getH() const {
+int ArbDisplay::getH() const {
     return h;
 }
 
-const Document* Display::getDocument() const
+const Document* ArbDisplay::getDocument() const
 {
     return document;
 }
 
-DisplayManager* Display::getDisplayManager() const
+ArbDisplayManager* ArbDisplay::getArbDisplayManager() const
 {
 	return displayManager;
 }
 
-void Display::resizeGL(const int w, const int h) {
+void ArbDisplay::resizeGL(const int w, const int h) {
 
     double ratio = QGuiApplication::primaryScreen()->devicePixelRatio();
 
@@ -86,7 +86,7 @@ void Display::resizeGL(const int w, const int h) {
     this->h = ratio*h;
 }
 
-void Display::paintGL() {
+void ArbDisplay::paintGL() {
     displayManager->drawBegin();
 
     glViewport(0,0,w,h);
@@ -103,7 +103,7 @@ void Display::paintGL() {
     axesRenderer->render();
 }
 
-void Display::keyPressEvent( QKeyEvent *k ) {
+void ArbDisplay::keyPressEvent( QKeyEvent *k ) {
     switch (k->key()) {
         case Qt::Key_Up:
             camera->processMoveRequest(0, keyPressSimulatedMouseMoveDistance);
@@ -124,6 +124,6 @@ void Display::keyPressEvent( QKeyEvent *k ) {
     }
 }
 
-OrthographicCamera *Display::getCamera() const {
+OrthographicCamera *ArbDisplay::getCamera() const {
     return camera;
 }

--- a/src/display/DisplayManager.cpp
+++ b/src/display/DisplayManager.cpp
@@ -17,23 +17,23 @@
  * License along with this file; see the file named COPYING for more
  * information.
  */
-/** @file DisplayManager.cpp */
+/** @file ArbDisplayManager.cpp */
 
 #include <QMatrix4x4>
 #include <QScreen>
-#include "DisplayManager.h"
+#include "ArbDisplayManager.h"
 
 #define DM_SOLID_LINE 0
 #define DM_DASHED_LINE 1
 
-DisplayManager::DisplayManager(Display &display) : display(display)
+ArbDisplayManager::ArbDisplayManager(ArbDisplay &display) : display(display)
 {
   /* FIXME: these curiously crash on Mac */
     setFGColor(0,0,0, 1);
     glLineStipple(1, 0xCF33);
 }
 
-bool DisplayManager::DrawVListElementCallback::operator()(BRLCAD::VectorList::Element *element) {
+bool ArbDisplayManager::DrawVListElementCallback::operator()(BRLCAD::VectorList::Element *element) {
     const  float black[4] = {0.0, 0.0, 0.0, 0.0};
     if (!element) return true;
 
@@ -80,9 +80,9 @@ bool DisplayManager::DrawVListElementCallback::operator()(BRLCAD::VectorList::El
             glGetFloatv(GL_MODELVIEW_MATRIX, _m);
             QMatrix4x4 m(_m);
             QVector3D point(e->ReferencePoint().coordinates[0], e->ReferencePoint().coordinates[1], e->ReferencePoint().coordinates[2]);
-            QVector3D tlate = m.transposed() * point;
+            QVector3D tlate = m.transposed().map(point);
             //todo changes to the last few lines are not yet tested.
-            class Display;
+            class ArbDisplay;
             glPushMatrix();
             glLoadIdentity();
             glTranslated(tlate[0], tlate[1], tlate[2]);
@@ -233,11 +233,11 @@ bool DisplayManager::DrawVListElementCallback::operator()(BRLCAD::VectorList::El
     return true;
 }
 
-DisplayManager::DrawVListElementCallback::DrawVListElementCallback(const DisplayManager *displayManager,
+ArbDisplayManager::DrawVListElementCallback::DrawVListElementCallback(const ArbDisplayManager *displayManager,
                                                                    DrawVlistVars *vars) :
     displayManager(displayManager), vars(vars) {}
 
-void DisplayManager::drawVList(BRLCAD::VectorList *vectorList)
+void ArbDisplayManager::drawVList(BRLCAD::VectorList *vectorList)
 {
     GLfloat originalPointSize, originalLineWidth;
     glGetFloatv(GL_POINT_SIZE, &originalPointSize);
@@ -260,7 +260,7 @@ void DisplayManager::drawVList(BRLCAD::VectorList *vectorList)
 }
 
 
-void DisplayManager::setFGColor(float r, float g, float b, float transparency) {
+void ArbDisplayManager::setFGColor(float r, float g, float b, float transparency) {
     wireColor[0] = r;
     wireColor[1] = g;
     wireColor[2] = b;
@@ -297,7 +297,7 @@ void DisplayManager::setFGColor(float r, float g, float b, float transparency) {
 }
 
 
-void DisplayManager::setBGColor(float r, float g, float b) {
+void ArbDisplayManager::setBGColor(float r, float g, float b) {
     bgColor[0] = r;
     bgColor[1] = g;
     bgColor[2] = b;
@@ -310,7 +310,7 @@ void DisplayManager::setBGColor(float r, float g, float b) {
  * DM_SOLID_LINE=0
  * DM_DASHED_LINE=1
  */
-void DisplayManager::setLineStyle(int style) {
+void ArbDisplayManager::setLineStyle(int style) {
     if (style == DM_DASHED_LINE) {
         glEnable(GL_LINE_STIPPLE);
     }
@@ -319,7 +319,7 @@ void DisplayManager::setLineStyle(int style) {
     }
 }
 
-void DisplayManager::setLineWidth(int width)
+void ArbDisplayManager::setLineWidth(int width)
 {
     glLineWidth((GLfloat) width);
 }
@@ -331,7 +331,7 @@ void DisplayManager::setLineWidth(int width)
  * DM_SOLID_LINE=0
  * DM_DASHED_LINE=1
  */
-void DisplayManager::setLineAttr(int width, int style)
+void ArbDisplayManager::setLineAttr(int width, int style)
 {
     if (width>0) {
         glLineWidth((GLfloat) width);
@@ -346,16 +346,16 @@ void DisplayManager::setLineAttr(int width, int style)
 }
 
 /*
- * Displays a saved display list identified by `list`
+ * ArbDisplays a saved display list identified by `list`
  */
-void DisplayManager::drawDList(unsigned int list) {
+void ArbDisplayManager::drawDList(unsigned int list) {
     glCallList((GLuint) list);
 }
 
 /*
  * Generates `range` number of display lists and returns first display list's index
  */
-unsigned int DisplayManager::genDLists(size_t range)
+unsigned int ArbDisplayManager::genDLists(size_t range)
 {
     return glGenLists((GLsizei)range);
 }
@@ -364,7 +364,7 @@ unsigned int DisplayManager::genDLists(size_t range)
  * Supported subsequent opengl commands are compiled into the display list `list` rather than being rendered to the screen.
  * Should have called genDLists and generated the display list before calling this.
  */
-void DisplayManager::beginDList(unsigned int list)
+void ArbDisplayManager::beginDList(unsigned int list)
 {
     glNewList((GLuint)list, GL_COMPILE);
 }
@@ -372,7 +372,7 @@ void DisplayManager::beginDList(unsigned int list)
 /*
  * End of the display list initiated by beginDList.
  */
-void DisplayManager::endDList()
+void ArbDisplayManager::endDList()
 {
     glEndList();
 }
@@ -380,16 +380,16 @@ void DisplayManager::endDList()
 /*
  * End of the display list initiated by beginDList.
  */
-GLboolean DisplayManager::isDListValid(unsigned int list)
+GLboolean ArbDisplayManager::isDListValid(unsigned int list)
 {
     return glIsList(list);
 }
 
-void DisplayManager::freeDLists(unsigned int list, int range)
+void ArbDisplayManager::freeDLists(unsigned int list, int range)
 {
     glDeleteLists((GLuint)list, (GLsizei)range);
 }
-void DisplayManager::drawBegin()
+void ArbDisplayManager::drawBegin()
 {
     glClearColor(bgColor[0],bgColor[1],bgColor[2],1);
     glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
@@ -400,35 +400,35 @@ void DisplayManager::drawBegin()
 
 }
 
-void DisplayManager::saveState(){
+void ArbDisplayManager::saveState(){
     glPushAttrib(GL_ALL_ATTRIB_BITS);
 }
-void DisplayManager::restoreState(){
+void ArbDisplayManager::restoreState(){
     glPopAttrib();
 }
 
-void DisplayManager::loadMatrix(const GLfloat *m)
+void ArbDisplayManager::loadMatrix(const GLfloat *m)
 {
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     glLoadMatrixf(m);
 }
-void DisplayManager::loadPMatrix(const GLfloat *m)
+void ArbDisplayManager::loadPMatrix(const GLfloat *m)
 {
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
     glLoadMatrixf(m);
 }
 
-void DisplayManager::setSuffix(const BRLCAD::VectorList& vectorList) {
+void ArbDisplayManager::setSuffix(const BRLCAD::VectorList& vectorList) {
     suffix = vectorList;
 }
 
-void DisplayManager::clearSuffix(void) {
+void ArbDisplayManager::clearSuffix(void) {
     suffix.Clear();
 }
 
-void DisplayManager::drawSuffix(void) {
+void ArbDisplayManager::drawSuffix(void) {
     setFGColor(1.0f, 1.0f, 0.0f, 1.0f);
     drawVList(&suffix);
 }

--- a/src/display/GeometryRenderer.cpp
+++ b/src/display/GeometryRenderer.cpp
@@ -28,22 +28,22 @@ GeometryRenderer::GeometryRenderer(Document* document) : document(document)
 }
 
 void GeometryRenderer::render() {
-    document->getDisplay()->getDisplayManager()->saveState();
-    if (!objectsToBeDisplayedIds.empty()) {
-        for (int objectId : objectsToBeDisplayedIds) {
-            if (!objectIdDisplayListIdMap.contains(objectId)) {
+    document->getArbDisplay()->getArbDisplayManager()->saveState();
+    if (!objectsToBeArbDisplayedIds.empty()) {
+        for (int objectId : objectsToBeArbDisplayedIds) {
+            if (!objectIdArbDisplayListIdMap.contains(objectId)) {
                 drawSolid(objectId);
             }
-            visibleDisplayListIds.append(objectIdDisplayListIdMap[objectId]);
+            visibleArbDisplayListIds.append(objectIdArbDisplayListIdMap[objectId]);
         }
-        objectsToBeDisplayedIds.clear();
+        objectsToBeArbDisplayedIds.clear();
     }
 
-    for (int displayListId : visibleDisplayListIds) {
-        document->getDisplay()->getDisplayManager()->drawDList(displayListId);
+    for (int displayListId : visibleArbDisplayListIds) {
+        document->getArbDisplay()->getArbDisplayManager()->drawDList(displayListId);
     }
-    document->getDisplay()->getDisplayManager()->drawSuffix();
-    document->getDisplay()->getDisplayManager()->restoreState();
+    document->getArbDisplay()->getArbDisplayManager()->drawSuffix();
+    document->getArbDisplay()->getArbDisplayManager()->restoreState();
 }
 
 
@@ -55,42 +55,42 @@ void GeometryRenderer::drawSolid(int objectId) {
 
     clearSolidIfAvailable(objectId);
 
-    const unsigned int displayListId = document->getDisplay()->getDisplayManager()->genDLists(1);
-    document->getDisplay()->getDisplayManager()->beginDList(displayListId);  // begin display list --------------
+    const unsigned int displayListId = document->getArbDisplay()->getArbDisplayManager()->genDLists(1);
+    document->getArbDisplay()->getArbDisplayManager()->beginDList(displayListId);  // begin display list --------------
 
     if (colorInfo.hasColor) {
-        document->getDisplay()->getDisplayManager()->setFGColor(colorInfo.red, colorInfo.green, colorInfo.blue, 1);
+        document->getArbDisplay()->getArbDisplayManager()->setFGColor(colorInfo.red, colorInfo.green, colorInfo.blue, 1);
     }
     else {
-        document->getDisplay()->getDisplayManager()->setFGColor(defaultWireColor[0], defaultWireColor[1], defaultWireColor[2], 1);
+        document->getArbDisplay()->getArbDisplayManager()->setFGColor(defaultWireColor[0], defaultWireColor[1], defaultWireColor[2], 1);
     }
 
     //displayManager->setLineStyle(tsp->ts_sofar & (TS_SOFAR_MINUS | TS_SOFAR_INTER));
-    document->getDisplay()->getDisplayManager()->drawVList(&vectorList);
-    document->getDisplay()->getDisplayManager()->endDList();     // end display list --------------
+    document->getArbDisplay()->getArbDisplayManager()->drawVList(&vectorList);
+    document->getArbDisplay()->getArbDisplayManager()->endDList();     // end display list --------------
 
-    objectIdDisplayListIdMap[objectId] = displayListId;
+    objectIdArbDisplayListIdMap[objectId] = displayListId;
 }
 
 
 
 void GeometryRenderer::refreshForVisibilityAndSolidChanges() {
-    visibleDisplayListIds.clear();
+    visibleArbDisplayListIds.clear();
     document->getObjectTree()->traverseSubTree(0, false,[this]
         (int objectId)
         {
             if (document->getObjectTree()->getObjectVisibility()[objectId] == ObjectTree::Invisible) return false;
             if (!document->getObjectTree()->getDrawableObjectIds().contains(objectId)) return true;
-            objectsToBeDisplayedIds.append(objectId);
+            objectsToBeArbDisplayedIds.append(objectId);
             return true;
         }
     );
 }
 
 void GeometryRenderer::clearSolidIfAvailable(int objectId) {
-    if (objectIdDisplayListIdMap.contains(objectId)){
-        document->getDisplay()->getDisplayManager()->freeDLists(objectIdDisplayListIdMap[objectId], 1);
-        objectIdDisplayListIdMap.remove(objectId);
+    if (objectIdArbDisplayListIdMap.contains(objectId)){
+        document->getArbDisplay()->getArbDisplayManager()->freeDLists(objectIdArbDisplayListIdMap[objectId], 1);
+        objectIdArbDisplayListIdMap.remove(objectId);
     }
 }
 

--- a/src/display/GridRenderer.cpp
+++ b/src/display/GridRenderer.cpp
@@ -18,7 +18,7 @@
 
 
 void GridRenderer::render() {
-    //todo implement line drawing in DisplayManager and use it instead of calling OpenGL here
+    //todo implement line drawing in ArbDisplayManager and use it instead of calling OpenGL here
 
     int lineCount = 1000;
     double lineGap;
@@ -27,7 +27,7 @@ void GridRenderer::render() {
     float length = lineCount*lineGap;
     float lineColor[] = {.3,.3,.3};
 
-    display->getDisplayManager()->saveState();  
+    display->getArbDisplayManager()->saveState();  
 
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
@@ -51,9 +51,9 @@ void GridRenderer::render() {
 
     glEnd();
 
-    display->getDisplayManager()->restoreState();
+    display->getArbDisplayManager()->restoreState();
 }
 
 
 
-GridRenderer::GridRenderer(Display *display) : display(display) {}
+GridRenderer::GridRenderer(ArbDisplay *display) : display(display) {}

--- a/src/display/MouseAction.cpp
+++ b/src/display/MouseAction.cpp
@@ -19,13 +19,13 @@
  */
 /** @file MouseAction.cpp */
 
-#include "DisplayGrid.h"
+#include "ArbDisplayGrid.h"
 #include "MouseAction.h"
 
 
-MouseAction::MouseAction(DisplayGrid* parent, Display* watched)
+MouseAction::MouseAction(ArbDisplayGrid* parent, ArbDisplay* watched)
     : QObject(parent), m_parent(parent), m_watched(watched) {
-    connect(m_watched, &Display::destroyed,
+    connect(m_watched, &ArbDisplay::destroyed,
             this,      &MouseAction::WatchedDestroyed);
 }
 

--- a/src/display/MoveCameraMouseAction.cpp
+++ b/src/display/MoveCameraMouseAction.cpp
@@ -19,11 +19,11 @@
  */
 /** @file MoveCameraMouseAction.cpp */
 
-#include "DisplayGrid.h"
+#include "ArbDisplayGrid.h"
 #include "MoveCameraMouseAction.h"
 
 
-MoveCameraMouseAction::MoveCameraMouseAction(DisplayGrid* parent, Display* watched)
+MoveCameraMouseAction::MoveCameraMouseAction(ArbDisplayGrid* parent, ArbDisplay* watched)
     : MouseAction(parent, watched) {
     m_watched->installEventFilter(this);
 }
@@ -36,10 +36,10 @@ bool MoveCameraMouseAction::eventFilter(QObject* watched, QEvent* event) {
     if (watched == m_watched) {
         if (event->type() == QEvent::MouseMove) {
             QMouseEvent* moveCameraEvent = static_cast<QMouseEvent *>(event);
-            const int x = moveCameraEvent->x();
-            const int y = moveCameraEvent->y();
-            int globalX = moveCameraEvent->globalX();
-            int globalY = moveCameraEvent->globalY();
+            const int x = moveCameraEvent->position().x();
+            const int y = moveCameraEvent->position().y();
+            int globalX = moveCameraEvent->globalPosition().x();
+            int globalY = moveCameraEvent->globalPosition().y();
 
             bool resetX = false, resetY = false;
 
@@ -97,11 +97,11 @@ bool MoveCameraMouseAction::eventFilter(QObject* watched, QEvent* event) {
             ret = true;
         }
         else if (event->type() == QEvent::MouseButtonPress) {
-            m_parent->setActiveDisplay(m_watched);
+            m_parent->setActiveArbDisplay(m_watched);
 
             QMouseEvent* mouseButtonPressEvent = static_cast<QMouseEvent*>(event);
-            prevMouseX = mouseButtonPressEvent->x();
-            prevMouseY = mouseButtonPressEvent->y();
+            prevMouseX = mouseButtonPressEvent->position().x();
+            prevMouseY = mouseButtonPressEvent->position().y();
 
             ret        = true;
         }

--- a/src/display/OrthographicCamera.cpp
+++ b/src/display/OrthographicCamera.cpp
@@ -79,10 +79,10 @@ void OrthographicCamera::processMoveRequest(const int &deltaX, const int &deltaY
     rotationMatrixAroundX.rotate(-angleAroundAxes.x(), axisX);
     QMatrix4x4 rotationMatrix = rotationMatrixAroundZ * rotationMatrixAroundY * rotationMatrixAroundX;
 
-    QVector3D cameraRightDirection(rotationMatrix * axisX);
+    QVector3D cameraRightDirection = rotationMatrix.map(axisX);
     eyePosition -= static_cast<float>(deltaX) * eyeMovementPerMouseDelta * cameraRightDirection * verticalSpan;
 
-    QVector3D cameraUpDirection(rotationMatrix * axisY);
+    QVector3D cameraUpDirection = rotationMatrix.map(axisY);
     eyePosition += static_cast<float>(deltaY) * eyeMovementPerMouseDelta * cameraUpDirection * verticalSpan;
 }
 
@@ -146,7 +146,7 @@ void OrthographicCamera::centerToCurrentSelection() {
     const BRLCAD::Vector3D volume = (a - b);
     double diagonalLength = vector3DLength(volume);
     if (diagonalLength > 0.001) setZoom(diagonalLength * 1.1);
-    document->getDisplay()->forceRerenderFrame();
+    document->getArbDisplay()->forceRerenderFrame();
 }
 
 void OrthographicCamera::autoview() {

--- a/src/display/PerspectiveCamera.cpp
+++ b/src/display/PerspectiveCamera.cpp
@@ -52,10 +52,10 @@ void PerspectiveCamera::processMoveRequest(const int & deltaX, const int & delta
     rotationMatrixAroundX.rotate(-angleAroundAxes.x(), axisX);
     QMatrix4x4 rotationMatrix = rotationMatrixAroundY * rotationMatrixAroundX;
 
-    QVector3D PerspectiveCameraRightDirection(rotationMatrix * axisX);
+    QVector3D PerspectiveCameraRightDirection = rotationMatrix.map(axisX);
     eyePosition += float(deltaX) * eyeMovementPerMouseDelta * PerspectiveCameraRightDirection;
 
-    QVector3D PerspectiveCameraUpDirection(rotationMatrix * axisY);
+    QVector3D PerspectiveCameraUpDirection = rotationMatrix.map(axisY);
     eyePosition += float(-deltaY) * eyeMovementPerMouseDelta * PerspectiveCameraUpDirection;
 }
 
@@ -66,7 +66,7 @@ void PerspectiveCamera::processZoomRequest(const int & deltaWheelAngle) {
     rotationMatrixAroundX.rotate(-angleAroundAxes.x(), axisX);
     QMatrix4x4 rotationMatrix = rotationMatrixAroundY * rotationMatrixAroundX;
 
-    QVector3D PerspectiveCameraForwardDirection(rotationMatrix * (-axisZ));
+    QVector3D PerspectiveCameraForwardDirection = rotationMatrix.map(-axisZ);
 
     eyePosition += -float(deltaWheelAngle) * eyeMovementPerWheelAngle * PerspectiveCameraForwardDirection;
 }

--- a/src/display/README.txt
+++ b/src/display/README.txt
@@ -1,8 +1,8 @@
-Display         -       the qt widget (QOpenGLWidget) that displays stuff, handle mouse move, asks all renderers to draw things
+ArbDisplay         -       the qt widget (QOpenGLWidget) that displays stuff, handle mouse move, asks all renderers to draw things
 Renderer        -       a virtual class, GeometryRenderer and AxesRenderer are subclasses
 GeometryRenderer-       manages rendering a database
 AxesRenderer    -       manages rendering axes
 Camera          -       a virtual class, input is mouse/keyboard events etc, outputs projection and modelview matrices. OrthographicCamera is a subclass
-DisplayManager  -       similar to dm_wgl.c. Renderers use this. (need to fix AxesRenderer to utilize this rather than direct opengl)
+ArbDisplayManager  -       similar to dm_wgl.c. Renderers use this. (need to fix AxesRenderer to utilize this rather than direct opengl)
 
-Display puts everything together
+ArbDisplay puts everything together

--- a/src/display/RaytraceView.cpp
+++ b/src/display/RaytraceView.cpp
@@ -31,6 +31,7 @@
 #include <cmath>
 
 #include <QPainter>
+#include <QMessageBox>
 
 #include "RaytraceView.h"
 #include <QBitmap>
@@ -173,17 +174,17 @@ void RaytraceView::raytrace() {
     );
 
     QMatrix4x4 transformation;
-    transformation.translate(document->getDisplay()->getCamera()->getEyePosition().x(),
-                             document->getDisplay()->getCamera()->getEyePosition().y(),
-                             document->getDisplay()->getCamera()->getEyePosition().z());
-    transformation.rotate(-document->getDisplay()->getCamera()->getAnglesAroundAxes().y(), 0., 1., 0.);
-    transformation.rotate(-document->getDisplay()->getCamera()->getAnglesAroundAxes().z(), 0., 0., 1.);
-    transformation.rotate(-document->getDisplay()->getCamera()->getAnglesAroundAxes().x(), 1., 0., 0.);
+    transformation.translate(document->getArbDisplay()->getCamera()->getEyePosition().x(),
+                             document->getArbDisplay()->getCamera()->getEyePosition().y(),
+                             document->getArbDisplay()->getCamera()->getEyePosition().z());
+    transformation.rotate(-document->getArbDisplay()->getCamera()->getAnglesAroundAxes().y(), 0., 1., 0.);
+    transformation.rotate(-document->getArbDisplay()->getCamera()->getAnglesAroundAxes().z(), 0., 0., 1.);
+    transformation.rotate(-document->getArbDisplay()->getCamera()->getAnglesAroundAxes().x(), 1., 0., 0.);
     transformation.translate(0, 0, 10000);
-    transformation.scale(document->getDisplay()->getCamera()->getVerticalSpan()/document->getDisplay()->getH());
-    transformation.translate(-document->getDisplay()->getW()/2.,-document->getDisplay()->getH()/2.);
+    transformation.scale(document->getArbDisplay()->getCamera()->getVerticalSpan()/document->getArbDisplay()->getH());
+    transformation.translate(-document->getArbDisplay()->getW()/2.,-document->getArbDisplay()->getH()/2.);
 
-    resize(document->getDisplay()->getW(),document->getDisplay()->getH());
+    resize(document->getArbDisplay()->getW(),document->getArbDisplay()->getH());
     UpdateTrafo(transformation);
     UpdateImage();
 

--- a/src/display/SelectMouseAction.cpp
+++ b/src/display/SelectMouseAction.cpp
@@ -20,16 +20,16 @@
  /** @file SelectMouseAction.cpp */
 
 #include "SelectMouseAction.h"
-#include "DisplayGrid.h"
+#include "ArbDisplayGrid.h"
 
 
-SelectMouseAction::SelectMouseAction(DisplayGrid* parent, Display* watched)
+SelectMouseAction::SelectMouseAction(ArbDisplayGrid* parent, ArbDisplay* watched)
     : MouseAction(parent, watched) {
     m_watched->installEventFilter(this);
 }
 
 SelectMouseAction::~SelectMouseAction() {
-    DisplayManager* displayManager = m_watched->getDisplayManager();
+    ArbDisplayManager* displayManager = m_watched->getArbDisplayManager();
     if (displayManager) {
         displayManager->clearSuffix();
         m_watched->forceRerenderFrame();
@@ -64,7 +64,7 @@ bool SelectMouseAction::eventFilter(QObject* watched, QEvent* event) {
                 QVector3D direction = directionEnd - directionStart;
                 direction.normalize();
 
-                QVector3D imagePoint(mouseEvent->x(), m_watched->getH() - mouseEvent->y() - 1., 0.);
+                QVector3D imagePoint(mouseEvent->position().x(), m_watched->getH() - mouseEvent->position().y() - 1., 0.);
                 QVector3D modelPoint = transformation.map(imagePoint);
                 
                 BRLCAD::Ray3D    ray;
@@ -84,8 +84,8 @@ bool SelectMouseAction::eventFilter(QObject* watched, QEvent* event) {
                     BRLCAD::VectorList vectorList;
                     const QString objectFullPath = m_selected;
                     m_watched->getDocument()->getDatabase()->Plot(objectFullPath.toUtf8(), vectorList);
-                    m_watched->getDisplayManager()->setSuffix(vectorList);
-                    m_watched->getDisplayManager()->drawSuffix();
+                    m_watched->getArbDisplayManager()->setSuffix(vectorList);
+                    m_watched->getArbDisplayManager()->drawSuffix();
                     m_watched->forceRerenderFrame();
                 }
             }

--- a/src/gui/AboutWindow.cpp
+++ b/src/gui/AboutWindow.cpp
@@ -1,4 +1,3 @@
-
 #include <QtWidgets/QLabel>
 #include <QBitmap>
 #include <QIcon>
@@ -8,7 +7,8 @@
 #include <algorithm>
 #include "AboutWindow.h"
 
-AboutWindow::AboutWindow() : QVBoxWidget() {
+AboutWindow::AboutWindow() : QVBoxWidget()
+{
 
     setWindowFlags(Qt::Window| Qt::WindowCloseButtonHint);
     setObjectName("aboutWindow");
@@ -196,5 +196,4 @@ AboutWindow::AboutWindow() : QVBoxWidget() {
 
     setMinimumWidth(std::max(icon->width()*1.02,intro->width()*1.02));
     setFixedHeight(QApplication::primaryScreen()->geometry().height() * .75);
-
 }

--- a/src/gui/AboutWindow.cpp
+++ b/src/gui/AboutWindow.cpp
@@ -2,7 +2,7 @@
 #include <QtWidgets/QLabel>
 #include <QBitmap>
 #include <QIcon>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QApplication>
 #include <QtWidgets/QScrollArea>
 #include <algorithm>
@@ -195,6 +195,6 @@ AboutWindow::AboutWindow() : QVBoxWidget() {
     scrollArea->setWidget(container);
 
     setMinimumWidth(std::max(icon->width()*1.02,intro->width()*1.02));
-    setFixedHeight(QApplication::desktop()->screenGeometry().height() * .75);
+    setFixedHeight(QApplication::primaryScreen()->geometry().height() * .75);
 
 }

--- a/src/gui/DisplayGrid.cpp
+++ b/src/gui/DisplayGrid.cpp
@@ -1,11 +1,11 @@
 
 #include <QtOpenGL/QtOpenGL>
-#include <include/Display.h>
-#include "DisplayGrid.h"
+#include <include/ArbDisplay.h>
+#include "ArbDisplayGrid.h"
 #include "MoveCameraMouseAction.h"
 #include "SelectMouseAction.h"
 
-DisplayGrid::DisplayGrid(Document*  document) : document(document) {
+ArbDisplayGrid::ArbDisplayGrid(Document*  document) : document(document) {
     verticalSplitter = new QSplitter(this);
     verticalSplitter->setOrientation(Qt::Vertical);
     horizontalSplitter1 = new QSplitter(this);
@@ -14,10 +14,10 @@ DisplayGrid::DisplayGrid(Document*  document) : document(document) {
     verticalSplitter->addWidget(horizontalSplitter1);
     verticalSplitter->addWidget(horizontalSplitter2);
 
-    displays.append(new Display(document));
-    displays.append(new Display(document));
-    displays.append(new Display(document));
-    displays.append(new Display(document));
+    displays.append(new ArbDisplay(document));
+    displays.append(new ArbDisplay(document));
+    displays.append(new ArbDisplay(document));
+    displays.append(new ArbDisplay(document));
 
     mouseActions.append(nullptr);
     mouseActions.append(nullptr);
@@ -30,51 +30,51 @@ DisplayGrid::DisplayGrid(Document*  document) : document(document) {
     horizontalSplitter2->addWidget(displays[3]);
 
     for(int i=0;i<4;i++){
-        displays[i]->getCamera()->setAnglesAroundAxes(defaultDisplayCameraRotation[i][0],
-                                                      defaultDisplayCameraRotation[i][1],
-                                                      defaultDisplayCameraRotation[i][2]);
+        displays[i]->getCamera()->setAnglesAroundAxes(defaultArbDisplayCameraRotation[i][0],
+                                                      defaultArbDisplayCameraRotation[i][1],
+                                                      defaultArbDisplayCameraRotation[i][2]);
     }
 
     addWidget(verticalSplitter);
-    activeDisplay = displays[3];
+    activeArbDisplay = displays[3];
 
-    singleDisplayMode(3);
+    singleArbDisplayMode(3);
 }
 
-void DisplayGrid::forceRerenderAllDisplays() {
-    for (Display *display : displays){
+void ArbDisplayGrid::forceRerenderAllArbDisplays() {
+    for (ArbDisplay *display : displays){
         display->forceRerenderFrame();
     }
 }
 
-void DisplayGrid::setActiveDisplay(Display *display) {
-    activeDisplay = display;
+void ArbDisplayGrid::setActiveArbDisplay(ArbDisplay *display) {
+    activeArbDisplay = display;
 }
 
-void DisplayGrid::resetViewPort(int displayId) {
-    displays[displayId]->getCamera()->setAnglesAroundAxes(defaultDisplayCameraRotation[displayId][0],
-                                                          defaultDisplayCameraRotation[displayId][1],
-                                                          defaultDisplayCameraRotation[displayId][2]);
+void ArbDisplayGrid::resetViewPort(int displayId) {
+    displays[displayId]->getCamera()->setAnglesAroundAxes(defaultArbDisplayCameraRotation[displayId][0],
+                                                          defaultArbDisplayCameraRotation[displayId][1],
+                                                          defaultArbDisplayCameraRotation[displayId][2]);
 
     displays[displayId]->getCamera()->autoview();
     displays[displayId]->forceRerenderFrame();
 }
 
-void DisplayGrid::resetAllViewPorts() {
+void ArbDisplayGrid::resetAllViewPorts() {
     for(int i=0;i<4;i++)resetViewPort(i);
 }
 
-void DisplayGrid::singleDisplayMode(int displayId) {
+void ArbDisplayGrid::singleArbDisplayMode(int displayId) {
     for(int i=0;i<4;i++){
         if (i != displayId)displays[i]->hide();
     }
     displays[displayId]->show();
-    activeDisplay = displays[displayId];
+    activeArbDisplay = displays[displayId];
     verticalSplitter->setHandleWidth(0);
 
-    forceRerenderAllDisplays();
+    forceRerenderAllArbDisplays();
 }
-void DisplayGrid::quadDisplayMode() {
+void ArbDisplayGrid::quadArbDisplayMode() {
     for(int i=0;i<4;i++){
         displays[i]->show();
     }
@@ -84,19 +84,19 @@ void DisplayGrid::quadDisplayMode() {
     horizontalSplitter1->setSizes(QList<int>({INT_MAX, INT_MAX}));
     horizontalSplitter2->setSizes(QList<int>({INT_MAX, INT_MAX}));
 
-    forceRerenderAllDisplays();
+    forceRerenderAllArbDisplays();
 }
 
-int DisplayGrid::getActiveDisplayId() {
-    for(int i=0;i<4;i++)if(displays[i]==activeDisplay)return i;
+int ArbDisplayGrid::getActiveArbDisplayId() {
+    for(int i=0;i<4;i++)if(displays[i]==activeArbDisplay)return i;
     return 3;
 }
 
-bool DisplayGrid::inQuadDisplayMode() {
+bool ArbDisplayGrid::inQuadArbDisplayMode() {
     return !displays[0]->isHidden() && !displays[1]->isHidden();
 }
 
-void DisplayGrid::setMoveCameraMouseAction() {
+void ArbDisplayGrid::setMoveCameraMouseAction() {
     int displaysSize = displays.size();
     for (int index = 0; index < displaysSize; ++index) {
         if (mouseActions[index] != nullptr) {
@@ -107,7 +107,7 @@ void DisplayGrid::setMoveCameraMouseAction() {
     }
 }
 
-void DisplayGrid::setSelectObjectMouseAction() {
+void ArbDisplayGrid::setSelectObjectMouseAction() {
     int displaysSize = displays.size();
     for (int index = 0; index < displaysSize; ++index) {
         if (mouseActions[index] != nullptr) {

--- a/src/gui/DragEditLineEdit.cpp
+++ b/src/gui/DragEditLineEdit.cpp
@@ -1,7 +1,7 @@
 
 #include "DragEditLineEdit.h"
 #include <QApplication>
-#include <QDesktopWidget>
+#include <QScreen>
 
 DragEditLineEdit::DragEditLineEdit(const QString &string, QWidget *parent) : DragEditLineEdit(parent) {
     setText(string);
@@ -16,7 +16,7 @@ DragEditLineEdit::DragEditLineEdit(QWidget *parent) : QLineEdit(parent) {
 void DragEditLineEdit::mouseMoveEvent(QMouseEvent *event) {
 
     if(initialY != -1 && (event->buttons() & Qt::MouseButton::LeftButton)) {
-        int globalY = event->globalY();
+        int globalY = event->globalPosition().y();
         int deltaY = initialY-globalY;
         int change = 0;
         if (deltaY > initialTolerance){
@@ -38,11 +38,11 @@ void DragEditLineEdit::mouseMoveEvent(QMouseEvent *event) {
 }
 
 void DragEditLineEdit::mousePressEvent(QMouseEvent *event) {
-    initialY = event->globalY();
+    initialY = event->globalPosition().y();
     initialValue = text().toDouble();
     lastEmittedGlobalY = initialY;
     QLineEdit::mousePressEvent(event);
-    screenHeight = QApplication::desktop()->screenGeometry().height();
+    screenHeight = QApplication::primaryScreen()->geometry().height();
 }
 
 void DragEditLineEdit::mouseReleaseEvent(QMouseEvent *event) {

--- a/src/gui/HelpWidget.cpp
+++ b/src/gui/HelpWidget.cpp
@@ -2,7 +2,7 @@
 #include <QtWidgets/QLabel>
 #include <QBitmap>
 #include <QIcon>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QApplication>
 #include <QtWidgets/QScrollArea>
 #include <algorithm>

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1,6 +1,6 @@
 #include <QtWidgets/QFileDialog>
 #include "MainWindow.h"
-#include "DisplayGrid.h"
+#include "ArbDisplayGrid.h"
 #include <Document.h>
 #include <QtWidgets/QLabel>
 #include <include/QSSPreprocessor.h>
@@ -152,7 +152,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createArb8Act);
 
@@ -170,7 +170,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createConeAct);
 
@@ -191,7 +191,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createEllipsoidAct);
 
@@ -210,7 +210,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createEllipticalTorusAct);
 
@@ -230,7 +230,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createHalfspaceAct);
 
@@ -250,7 +250,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createHyperbolicCylinderAct);
 
@@ -270,7 +270,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createHyperboloidAct);
 
@@ -291,7 +291,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createParabolicCylinderAct);
 
@@ -312,7 +312,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createParaboloidAct);
 
@@ -332,7 +332,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createParticleAct);
 
@@ -351,7 +351,7 @@ void MainWindow::prepareUi() {
         documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
         documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
         documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getDisplayGrid()->forceRerenderAllDisplays();
+        documents[activeDocumentId]->getArbDisplayGrid()->forceRerenderAllArbDisplays();
     });
     createMenu->addAction(createTorusAct);
 
@@ -401,7 +401,7 @@ void MainWindow::prepareUi() {
     resetViewportAct->setStatusTip(tr("Reset to default camera orientation for the viewport and autoview to currently visible objects"));
     connect(resetViewportAct, &QAction::triggered, this, [this](){
         if (activeDocumentId == -1) return;
-        documents[activeDocumentId]->getDisplayGrid()->resetViewPort(documents[activeDocumentId]->getDisplayGrid()->getActiveDisplayId());
+        documents[activeDocumentId]->getArbDisplayGrid()->resetViewPort(documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplayId());
     });
     viewMenu->addAction(resetViewportAct);
 
@@ -410,7 +410,7 @@ void MainWindow::prepareUi() {
     resetAllViewportsAct->setStatusTip(tr("Reset to default camera orientation for each viewport and autoview to visible objects"));
     connect(resetAllViewportsAct, &QAction::triggered, this, [this](){
         if (activeDocumentId == -1) return;
-        documents[activeDocumentId]->getDisplayGrid()->resetAllViewPorts();
+        documents[activeDocumentId]->getArbDisplayGrid()->resetAllViewPorts();
     });
     viewMenu->addAction(resetAllViewportsAct);
 
@@ -422,7 +422,7 @@ void MainWindow::prepareUi() {
     autoViewAct->setStatusTip(tr("Resize and center the view based on the current visible objects"));
     connect(autoViewAct, &QAction::triggered, this, [this](){
         if (activeDocumentId == -1) return;
-        for(Display * display : documents[activeDocumentId]->getDisplayGrid()->getDisplays()){
+        for(ArbDisplay * display : documents[activeDocumentId]->getArbDisplayGrid()->getArbDisplays()){
             display->getCamera()->autoview();
             display->forceRerenderFrame();
         }
@@ -433,8 +433,8 @@ void MainWindow::prepareUi() {
     autoViewSingleAct->setStatusTip(tr("Resize and center the view based on the current visible objects"));
     connect(autoViewSingleAct, &QAction::triggered, this, [this](){
         if (activeDocumentId == -1) return;
-        documents[activeDocumentId]->getDisplay()->getCamera()->autoview();
-        documents[activeDocumentId]->getDisplay()->forceRerenderFrame();
+        documents[activeDocumentId]->getArbDisplay()->getCamera()->autoview();
+        documents[activeDocumentId]->getArbDisplay()->forceRerenderFrame();
     });
     viewMenu->addAction(autoViewSingleAct);
 
@@ -446,7 +446,7 @@ void MainWindow::prepareUi() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
         int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
-        documents[activeDocumentId]->getDisplay()->getCamera()->centerView(objectId);
+        documents[activeDocumentId]->getArbDisplay()->getCamera()->centerView(objectId);
     });
     viewMenu->addAction(centerViewAct);
     
@@ -461,10 +461,10 @@ void MainWindow::prepareUi() {
         singleViewAct[i] = new QAction("Viewport " + QString::number(i+1), this);
         viewportMenuGroup->addAction(singleViewAct[i]);
         singleViewAct[i]->setCheckable(true);
-        singleViewAct[i]->setStatusTip("Display viewport " + QString::number(i+1));
+        singleViewAct[i]->setStatusTip("ArbDisplay viewport " + QString::number(i+1));
         connect(singleViewAct[i], &QAction::triggered, this, [this,i]() {
             if (activeDocumentId == -1) return;
-            documents[activeDocumentId]->getDisplayGrid()->singleDisplayMode(i);
+            documents[activeDocumentId]->getArbDisplayGrid()->singleArbDisplayMode(i);
             currentViewport->setCurrentIndex(i);
         });
         singleView->addAction(singleViewAct[i]);
@@ -476,10 +476,10 @@ void MainWindow::prepareUi() {
     singleViewAct[3]->setChecked(true);
 
     QAction* quadViewAct = new QAction(tr("All Viewports"), this);
-    quadViewAct->setStatusTip(tr("Display 4 viewports"));
+    quadViewAct->setStatusTip(tr("ArbDisplay 4 viewports"));
     connect(quadViewAct, &QAction::triggered, this, [this](){
         if (activeDocumentId == -1) return;
-        documents[activeDocumentId]->getDisplayGrid()->quadDisplayMode();
+        documents[activeDocumentId]->getArbDisplayGrid()->quadArbDisplayMode();
         for(QAction *i : singleViewAct) i->setChecked(false);
         currentViewport->setCurrentIndex(4);
     });
@@ -498,16 +498,16 @@ void MainWindow::prepareUi() {
             return;
         }
 
-        if (documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->gridEnabled == false) {
-            documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->gridEnabled = true;
+        if (documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplay()->gridEnabled == false) {
+            documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplay()->gridEnabled = true;
             toggleGridAct->setToolTip("Toggle grid OFF (G)");
         }
         else {
-            documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->gridEnabled = false;
+            documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplay()->gridEnabled = false;
             toggleGridAct->setToolTip("Toggle grid ON (G)");
         }
 
-        documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->forceRerenderFrame();
+        documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplay()->forceRerenderFrame();
     });
     viewMenu->addAction(toggleGridAct);
 
@@ -715,8 +715,8 @@ void MainWindow::prepareUi() {
     currentViewport->setCurrentIndex(3);
     connect(currentViewport, QOverload<int>::of(&QComboBox::activated),[=](int index){
         if (activeDocumentId == -1) return;
-        if (index <4) documents[activeDocumentId]->getDisplayGrid()->singleDisplayMode(index);
-        else documents[activeDocumentId]->getDisplayGrid()->quadDisplayMode();
+        if (index <4) documents[activeDocumentId]->getArbDisplayGrid()->singleArbDisplayMode(index);
+        else documents[activeDocumentId]->getArbDisplayGrid()->quadArbDisplayMode();
         for(QAction *i : singleViewAct) i->setChecked(false);
         if(index != 4) singleViewAct[index]->setChecked(true);
     });
@@ -779,7 +779,7 @@ void MainWindow::newFile() {
     document->getProperties()->setObjectName("dockableContent");
     documents[documentsCount++] = document;
     QString filename("Untitled");
-    const int tabIndex = documentArea->addTab(document->getDisplayGrid(), filename);
+    const int tabIndex = documentArea->addTab(document->getArbDisplayGrid(), filename);
     documentArea->setCurrentIndex(tabIndex);
     connect(documents[activeDocumentId]->getObjectTreeWidget(), &ObjectTreeWidget::selectionChanged,
             this, &MainWindow::objectTreeWidgetSelectionChanged);
@@ -806,7 +806,7 @@ void MainWindow::openFile(const QString& filePath) {
         document->getProperties()->setObjectName("dockableContent");
         documents[documentsCount++] = document;
         QString filename(QFileInfo(filePath).fileName());
-        const int tabIndex = documentArea->addTab(document->getDisplayGrid(), filename);
+        const int tabIndex = documentArea->addTab(document->getArbDisplayGrid(), filename);
         documentArea->setCurrentIndex(tabIndex);
         connect(documents[activeDocumentId]->getObjectTreeWidget(), &ObjectTreeWidget::selectionChanged,
                 this, &MainWindow::objectTreeWidgetSelectionChanged);
@@ -896,7 +896,7 @@ bool MainWindow::saveFileDefaultPathId(int documentId) {
 bool MainWindow::maybeSave(int documentId, bool *cancel) {
     // Checks if the document has any unsaved changes
     if (documents[documentId]->isModified()) {
-        QFileInfo pathName = documents[documentId]->getFilePath() != nullptr ? *documents[documentId]->getFilePath() : "Untitled";
+        QFileInfo pathName(documents[documentId]->getFilePath() != nullptr ? *documents[documentId]->getFilePath() : "Untitled");
 
         QMessageBox msgBox;
         msgBox.setIcon(QMessageBox::Warning);
@@ -931,7 +931,7 @@ bool MainWindow::maybeSave(int documentId, bool *cancel) {
 }
 
 void MainWindow::onActiveDocumentChanged(const int newIndex){
-    DisplayGrid * displayGrid = dynamic_cast<DisplayGrid*>(documentArea->widget(newIndex));
+    ArbDisplayGrid * displayGrid = dynamic_cast<ArbDisplayGrid*>(documentArea->widget(newIndex));
     if (displayGrid != nullptr){
         if (displayGrid->getDocument()->getDocumentId() != activeDocumentId){
             activeDocumentId = displayGrid->getDocument()->getDocumentId();
@@ -939,13 +939,13 @@ void MainWindow::onActiveDocumentChanged(const int newIndex){
             objectPropertiesDockable->setContent(documents[activeDocumentId]->getProperties());
             statusBarPathLabel->setText(documents[activeDocumentId]->getFilePath()  != nullptr ? *documents[activeDocumentId]->getFilePath() : "Untitled");
 
-            if(documents[activeDocumentId]->getDisplayGrid()->inQuadDisplayMode()){
+            if(documents[activeDocumentId]->getArbDisplayGrid()->inQuadArbDisplayMode()){
                 currentViewport->setCurrentIndex(4);
                 for(QAction * action:singleViewAct) action->setChecked(false);
             }else {
-                currentViewport->setCurrentIndex(documents[activeDocumentId]->getDisplayGrid()->getActiveDisplayId());
+                currentViewport->setCurrentIndex(documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplayId());
                 for(QAction * action:singleViewAct) action->setChecked(false);
-                singleViewAct[documents[activeDocumentId]->getDisplayGrid()->getActiveDisplayId()]->setChecked(true);
+                singleViewAct[documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplayId()]->setChecked(true);
             }
         }
     }else if (activeDocumentId != -1){
@@ -959,7 +959,7 @@ void MainWindow::onActiveDocumentChanged(const int newIndex){
 void MainWindow::tabCloseRequested(const int i)
 {
     int documentId = -1;
-    DisplayGrid* displayGrid = dynamic_cast<DisplayGrid*>(documentArea->widget(i));
+    ArbDisplayGrid* displayGrid = dynamic_cast<ArbDisplayGrid*>(documentArea->widget(i));
     
     if (displayGrid != nullptr) {
         documentId = displayGrid->getDocument()->getDocumentId();
@@ -1009,7 +1009,7 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
             QMouseEvent* mouse_event = dynamic_cast<QMouseEvent*>(event);
             if (mouse_event->button() == Qt::LeftButton)
             {
-                dragPosition = mouse_event->globalPos() - frameGeometry().topLeft();
+                dragPosition = mouse_event->globalPosition().toPoint() - frameGeometry().topLeft();
                 return false;
             }
         }
@@ -1020,7 +1020,7 @@ bool MainWindow::eventFilter(QObject *watched, QEvent *event)
             {
                 if(isMaximized()) return false;//showNormal();
                 //todo showNormal when dragged
-                move(mouse_event->globalPos() - dragPosition);
+                move(mouse_event->globalPosition().toPoint() - dragPosition);
                 return false;
             }
         }
@@ -1042,10 +1042,10 @@ void MainWindow::changeEvent( QEvent* e ) {
 void MainWindow::closeEvent(QCloseEvent* event) {
     int documentSize = documents.size();
     bool cancel = false;
-    DisplayGrid * displayGrid = nullptr;
+    ArbDisplayGrid * displayGrid = nullptr;
 
     for (int documentIndex = 1; documentIndex <= documentSize; ++documentIndex) {
-        displayGrid = dynamic_cast<DisplayGrid*>(documentArea->widget(documentIndex));
+        displayGrid = dynamic_cast<ArbDisplayGrid*>(documentArea->widget(documentIndex));
         int documentId = displayGrid->getDocument()->getDocumentId();
         
         if (maybeSave(documentId, &cancel)) {
@@ -1066,7 +1066,7 @@ void MainWindow::closeEvent(QCloseEvent* event) {
 
 void MainWindow::moveCameraButtonAction() {
     if (activeDocumentId != -1) {
-        DisplayGrid* displayGrid = documents[activeDocumentId]->getDisplayGrid();
+        ArbDisplayGrid* displayGrid = documents[activeDocumentId]->getArbDisplayGrid();
 
         if (displayGrid != nullptr) {
             displayGrid->setMoveCameraMouseAction();
@@ -1075,7 +1075,7 @@ void MainWindow::moveCameraButtonAction() {
 }
 
 void MainWindow::selectObjectButtonAction() {
-    DisplayGrid* displayGrid = documents[activeDocumentId]->getDisplayGrid();
+    ArbDisplayGrid* displayGrid = documents[activeDocumentId]->getArbDisplayGrid();
 
     if (displayGrid != nullptr) {
         displayGrid->setSelectObjectMouseAction();
@@ -1089,12 +1089,12 @@ void MainWindow::updateMouseButtonObjectState() {
     }
 
     if (selectObjectAct->isChecked() == true) {
-        documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->moveCameraEnabled = false;
+        documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplay()->moveCameraEnabled = false;
         selectObjectAct->setToolTip("Select Object OFF");
         selectObjectButtonAction();
     }
-    else if (documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->moveCameraEnabled == false) {
-        documents[activeDocumentId]->getDisplayGrid()->getActiveDisplay()->moveCameraEnabled = true;
+    else if (documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplay()->moveCameraEnabled == false) {
+        documents[activeDocumentId]->getArbDisplayGrid()->getActiveArbDisplay()->moveCameraEnabled = true;
         selectObjectAct->setToolTip("Select Object ON");
         moveCameraButtonAction();
     }

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -65,13 +65,13 @@ ObjectTreeWidget::ObjectTreeWidget(Document* document, QWidget* parent) : docume
                 break;
         }
         this->document->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        this->document->getDisplayGrid()->forceRerenderAllDisplays();
+        this->document->getArbDisplayGrid()->forceRerenderAllArbDisplays();
         refreshItemTextColors();
     });
 
     connect(visibilityButton, &ObjectTreeRowButtons::centerButtonClicked, this, [this](int objectId){
-        this->document->getDisplay()->getCamera()->centerView(objectId);
-        this->document->getDisplayGrid()->forceRerenderAllDisplays();
+        this->document->getArbDisplay()->getCamera()->centerView(objectId);
+        this->document->getArbDisplayGrid()->forceRerenderAllArbDisplays();
         refreshItemTextColors();
     });
     refreshItemTextColors();

--- a/src/gui/QVBoxWidget.cpp
+++ b/src/gui/QVBoxWidget.cpp
@@ -6,7 +6,7 @@ QVBoxWidget::QVBoxWidget(QWidget *parent, Qt::WindowFlags f) : QFrame(parent, f)
     boxLayout = new QVBoxLayout(this);
     boxLayout->setContentsMargins(0, 0, 0, 0);
     boxLayout->setSpacing(0);
-    boxLayout->setMargin(0);
+    // boxLayout->setMargin(0);
     setLayout(boxLayout);
 }
 

--- a/src/gui/TypeSpecificProperties.cpp
+++ b/src/gui/TypeSpecificProperties.cpp
@@ -88,7 +88,7 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
             });
             this->document.getObjectTree()->buildColorMap(objectId);
             this->document.modifyObjectNoSet(objectId);
-            this->document.getDisplayGrid()->forceRerenderAllDisplays();
+            this->document.getArbDisplayGrid()->forceRerenderAllArbDisplays();
         });*/
     }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,22 +1,23 @@
-//#define ARB_DEBUG
+#define ARB_DEBUG
 
 #include <QApplication>
 #include <QOpenGLWidget>
 #include "MainWindow.h"
 
-int main(int argc, char*argv[]) {
+int main(int argc, char *argv[]) {
 
 #ifdef ARB_DEBUG
     if (argc < 2) {
-        argv = new char* [2]{ argv[0], "C:/Users/Sadeep/Desktop/moss.g" };
+        argv = new char* [2]{ argv[0], "../extra/db/moss.g" };
         argc = 2;
     }
 #endif
 
-
     QApplication app(argc,argv);
+
     MainWindow mainWindow;
     mainWindow.showMaximized();
+
     return app.exec();
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,7 +1,7 @@
 //#define ARB_DEBUG
 
 #include <QApplication>
-#include <DisplayGrid.h>
+#include <QOpenGLWidget>
 #include "MainWindow.h"
 
 int main(int argc, char*argv[]) {

--- a/src/utils/Utils.cpp
+++ b/src/utils/Utils.cpp
@@ -41,17 +41,16 @@ double vector3DLength(const BRLCAD::Vector3D& a)
 QString breakStringAtCaps(const QString& in)
 {
     QString newName;
-    for (int i = 0; i < in.size(); i++)
-    {
+    for (int i = 0; i < in.size(); i++) {
         if (in[i].isUpper() && i != 0) newName += " ";
         newName += in[i];
     }
     return newName;
 }
 
-const double * getLeafMatrix(BRLCAD::Combination::ConstTreeNode& node, const QString& name) {
-    switch (node.Operation())
-    {
+const double * getLeafMatrix(BRLCAD::Combination::ConstTreeNode& node, const QString& name)
+{
+    switch (node.Operation()) {
         case BRLCAD::Combination::ConstTreeNode::Union:
         case BRLCAD::Combination::ConstTreeNode::Intersection:
         case BRLCAD::Combination::ConstTreeNode::Subtraction:
@@ -71,9 +70,7 @@ const double * getLeafMatrix(BRLCAD::Combination::ConstTreeNode& node, const QSt
 
         case BRLCAD::Combination::ConstTreeNode::Leaf: {
             QString leafName = QString(node.Name());
-            if (leafName == name) {
-                return node.Matrix();
-            }
+            if (leafName == name) return node.Matrix();
             return nullptr;
         }
 
@@ -85,9 +82,9 @@ const double * getLeafMatrix(BRLCAD::Combination::ConstTreeNode& node, const QSt
     return nullptr;
 }
 
-void setLeafMatrix(BRLCAD::Combination::TreeNode& node, const QString& name, double * matrix) {
-    switch (node.Operation())
-    {
+void setLeafMatrix(BRLCAD::Combination::TreeNode& node, const QString& name, double * matrix)
+{
+    switch (node.Operation()) {
         case BRLCAD::Combination::ConstTreeNode::Union:
         case BRLCAD::Combination::ConstTreeNode::Intersection:
         case BRLCAD::Combination::ConstTreeNode::Subtraction:
@@ -116,16 +113,17 @@ void setLeafMatrix(BRLCAD::Combination::TreeNode& node, const QString& name, dou
     }
 }
 
-QImage coloredIcon(QString path, QString colorKey){
+QImage coloredIcon(QString path, QString colorKey)
+{
     QColor color;
-    if (colorKey == ""){
+    if (colorKey == "") {
         color = Globals::theme->getColor("$Color-Icon");
-    }else {
+    } else {
         color = Globals::theme->getColor(colorKey);
     }
 
-    QImage oldImage =  QImage(path);
-    QImage image = QImage(oldImage.size(),QImage::Format_ARGB32);
+    QImage oldImage = QImage(path);
+    QImage image = QImage(oldImage.size(), QImage::Format_ARGB32);
 
     for (int y = 0; y < image.height(); y++) {
         for (int x = 0; x < image.width(); x++) {
@@ -139,7 +137,8 @@ QImage coloredIcon(QString path, QString colorKey){
     return image;
 }
 
-bool getObjectNameFromUser(QWidget* parent, Document& document, QString& name) {
+bool getObjectNameFromUser(QWidget* parent, Document& document, QString& name)
+{
     bool ok;
 
     while (true) {
@@ -148,15 +147,12 @@ bool getObjectNameFromUser(QWidget* parent, Document& document, QString& name) {
         if (ok) {
             if (name.isEmpty()) {
                 QMessageBox::information(parent, QObject::tr("Object Name"), QObject::tr("Please enter an object name"), QMessageBox::Ok);
-            }
-            else if (document.getDatabase()->Get(name.toUtf8().data())) {
+            } else if (document.getDatabase()->Get(name.toUtf8().data())) {
                 QMessageBox::information(parent, QObject::tr("Object Name"), QObject::tr("Please enter an unique object name"), QMessageBox::Ok);
-            }
-            else {
+            } else {
                 break;
             }
-        }
-        else {
+        } else {
             break;
         }
     }


### PR DESCRIPTION
1. Migrated from _Qt5.14.2_ to _Qt6.4.2_. Now **Arbalest** compiles in _Qt6.4.2_ without any error or warning.
2. During the migration I also partially cleaned up the code in order to follow the **BRL-CAD Style Rules**.
3. Added functionaly to _drag MainWindow while it is maximized_:
    - dragging the title bar while the MainWindow is maximized in order to move it around (without manually having to press the maximized button to make the MainWindow windowed) is now possible;
    - now it isn't possible to drag the MainWindow around while a menu is open, making it so that visual bugs where a menu doesn't appear in the correct place in relation with the MainWindow won't happen anymore;
    - now it isn't possible to drag the MainWindow around after the title bar was grabbed from one of its buttons (maximize, minimize and close buttons);
    - the top left Arbalest icon, even though it is a QPushButton does't operate like the other buttons, so it is possible to move the MainWindow by grabbing the application icon.