### PR TITLE
Removed `using` directives in header files

### DIFF
--- a/include/Utils.h
+++ b/include/Utils.h
@@ -12,7 +12,6 @@
 #include <stack>
 #include <iostream>
 using namespace std::chrono;
-using namespace std;
 
 BRLCAD::Vector3D operator+(const BRLCAD::Vector3D& a, const BRLCAD::Vector3D& b);
 BRLCAD::Vector3D operator-(const BRLCAD::Vector3D& a, const BRLCAD::Vector3D& b);
@@ -91,8 +90,8 @@ inline void te(){
     time_point<high_resolution_clock> startTime = times.top();
 
     milliseconds duration = duration_cast<milliseconds>( high_resolution_clock::now()-startTime);
-    cout << timerNames.top().toStdString()<< "  "<<duration_cast<milliseconds>( high_resolution_clock::now()-startTime).count() <<" ms        "
-    <<duration_cast<microseconds>( high_resolution_clock::now()-startTime).count()<<" us"<< endl;
+    std::cout << timerNames.top().toStdString()<< "  "<<duration_cast<milliseconds>( high_resolution_clock::now()-startTime).count() <<" ms        "
+    <<duration_cast<microseconds>( high_resolution_clock::now()-startTime).count()<<" us"<< std::endl;
 }
 
 class Document;

--- a/include/Utils.h
+++ b/include/Utils.h
@@ -11,7 +11,6 @@
 #include <chrono>
 #include <stack>
 #include <iostream>
-using namespace std::chrono;
 
 BRLCAD::Vector3D operator+(const BRLCAD::Vector3D& a, const BRLCAD::Vector3D& b);
 BRLCAD::Vector3D operator-(const BRLCAD::Vector3D& a, const BRLCAD::Vector3D& b);
@@ -79,19 +78,20 @@ inline QWidget * toolbarSeparator(bool horizontal){
 
 QImage coloredIcon(QString path, QString colorKey = "");
 
-static std::stack <time_point<high_resolution_clock>> times;
+static std::stack <std::chrono::time_point<std::chrono::high_resolution_clock>> times;
 static std::stack <QString> timerNames;
 inline void ts(QString name = "Timer"){
-    times.push(high_resolution_clock::now());
+    times.push(std::chrono::high_resolution_clock::now());
     timerNames.push(name);
 }
 
 inline void te(){
-    time_point<high_resolution_clock> startTime = times.top();
+    std::chrono::time_point<std::chrono::high_resolution_clock> startTime = times.top();
 
-    milliseconds duration = duration_cast<milliseconds>( high_resolution_clock::now()-startTime);
-    std::cout << timerNames.top().toStdString()<< "  "<<duration_cast<milliseconds>( high_resolution_clock::now()-startTime).count() <<" ms        "
-    <<duration_cast<microseconds>( high_resolution_clock::now()-startTime).count()<<" us"<< std::endl;
+    std::chrono::milliseconds duration = std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now()-startTime);
+    std::cout << timerNames.top().toStdString() << "  "
+              << std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::high_resolution_clock::now()-startTime).count() << " ms        "
+              << std::chrono::duration_cast<std::chrono::microseconds>(std::chrono::high_resolution_clock::now()-startTime).count() << " us" << std::endl;
 }
 
 class Document;

--- a/src/gui/TypeSpecificProperties.cpp
+++ b/src/gui/TypeSpecificProperties.cpp
@@ -83,7 +83,7 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
                 editableComb.SetRed(selectedColor.redF());
                 editableComb.SetGreen(selectedColor.greenF());
                 editableComb.SetBlue(selectedColor.blueF());
-                cout<<selectedColor.redF()<<" "<<selectedColor.greenF()<<" "<<selectedColor.blueF()<<endl;
+                std::cout<<selectedColor.redF()<<" "<<selectedColor.greenF()<<" "<<selectedColor.blueF()<<std::endl;
                 this->document.getDatabase()->Set(editableComb);
             });
             this->document.getObjectTree()->buildColorMap(objectId);


### PR DESCRIPTION
When building arbalest I got the error `rpcndr.h: 'byte': ambiguous symbol`.

This problem is caused by a [known issue with Windows headers](https://developercommunity.visualstudio.com/t/93889).

To fix it I removed `using namespace std` in *Utils.h* to avoid the error in `rpcndr.h` (and possibly other header files) and changed all the few instances where this statement was meaningful by manually adding `std::`