### PR TITLE
Idea for new ObjectTree

### DIFF
--- a/include/Document.h
+++ b/include/Document.h
@@ -90,7 +90,7 @@ public:
     }
 
     bool isModified();
-    bool Add(const BRLCAD::Object& object);
+    bool AddObject(const BRLCAD::Object& object, const bool isVisible);
     bool Save(const char* fileName);
     void getBRLCADConstObject(const QString& objectName, const std::function<void(const BRLCAD::Object&)>& func) const;
     void getBRLCADObject(const QString& objectName, const std::function<void(BRLCAD::Object&)>& func);

--- a/include/GeometryRenderer.h
+++ b/include/GeometryRenderer.h
@@ -44,10 +44,10 @@ private:
     void drawSolid(size_t objectId);
 
     // Contains generated display list alone with corresponding objectId. objectId is the key. displayListId is value.
-    QHash<int, int>             objectIdViewportListIdMap;
+    QHash<size_t, size_t>             objectIdViewportListIdMap;
 
-    QVector<int> visibleViewportListIds;
-    QVector<int> objectsToBeViewportedIds;
+    QVector<size_t> visibleViewportListIds;
+    QVector<size_t> objectsToBeViewportedIds;
 };
 
 

--- a/include/GeometryRenderer.h
+++ b/include/GeometryRenderer.h
@@ -33,15 +33,15 @@ public:
     // this is called by Viewport to render a single frame
     void render() override;
     void refreshForVisibilityAndSolidChanges();
-    void clearSolidIfAvailable(int objectId);
-    void clearObject(int objectId);
+    void clearSolidIfAvailable(unsigned int objectId);
+    void clearObject(unsigned int objectId);
 
 private:
     Document* document;
     float defaultWireColor[3] = {1.0,.1,.4};
 
 
-    void drawSolid(int objectId);
+    void drawSolid(unsigned int objectId);
 
     // Contains generated display list alone with corresponding objectId. objectId is the key. displayListId is value.
     QHash<int, int>             objectIdViewportListIdMap;

--- a/include/GeometryRenderer.h
+++ b/include/GeometryRenderer.h
@@ -33,15 +33,15 @@ public:
     // this is called by Viewport to render a single frame
     void render() override;
     void refreshForVisibilityAndSolidChanges();
-    void clearSolidIfAvailable(unsigned int objectId);
-    void clearObject(unsigned int objectId);
+    void clearSolidIfAvailable(size_t objectId);
+    void clearObject(size_t objectId);
 
 private:
     Document* document;
     float defaultWireColor[3] = {1.0,.1,.4};
 
 
-    void drawSolid(unsigned int objectId);
+    void drawSolid(size_t objectId);
 
     // Contains generated display list alone with corresponding objectId. objectId is the key. displayListId is value.
     QHash<int, int>             objectIdViewportListIdMap;

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -94,7 +94,7 @@ public slots:
     bool saveFileDefaultPathId(int documentId);
     void onActiveDocumentChanged(int newIndex);
     void tabCloseRequested(int i) ;
-    void objectTreeWidgetSelectionChanged(int objectId);
+    void objectTreeWidgetSelectionChanged(unsigned int objectId);
     void newFile(); // empty new file
     void openFile(const QString& filePath);
     void updateMouseButtonObjectState();

--- a/include/MainWindow.h
+++ b/include/MainWindow.h
@@ -94,7 +94,7 @@ public slots:
     bool saveFileDefaultPathId(int documentId);
     void onActiveDocumentChanged(int newIndex);
     void tabCloseRequested(int i) ;
-    void objectTreeWidgetSelectionChanged(unsigned int objectId);
+    void objectTreeWidgetSelectionChanged(size_t objectId);
     void newFile(); // empty new file
     void openFile(const QString& filePath);
     void updateMouseButtonObjectState();

--- a/include/MatrixTransformWidget.h
+++ b/include/MatrixTransformWidget.h
@@ -9,9 +9,9 @@
 class MatrixTransformWidget : public DataRow{
 public:
     enum TransformType {Translate, Rotate, Scale};
-    MatrixTransformWidget(Document * document, int childObjectId, TransformType transformType );
+    MatrixTransformWidget(Document * document, size_t childObjectId, TransformType transformType);
 private:
-    static QHash<int,QWidget*> widgets;
+    static QHash<size_t,QWidget*> widgets;
 };
 
 

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -45,7 +45,7 @@
                ...
              comb2.c
                 |_____ u obj
-       - might have a different visibility state:
+       - might have a different visibility state
 
    So with the use of these 2 classes, we can represent what is SHARED across ALL occurrences in a database
    of an object through ObjectTreeItemData, and what is UNIQUE FOR EACH occurrences in a database of an

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -195,13 +195,20 @@ public:
 
     int lastAllocatedId = 0;
 
+    unsigned int nLastAllocatedId = 0;
+
     void traverseSubTree(int rootOfSubTreeId, bool traverseRoot, const std::function<bool(int)>&);
+    void nTraverseSubTree(ObjectTreeItem *rootOfSubTree, bool traverseRoot, const std::function<bool(ObjectTreeItem*)>& callback);
 
     void changeVisibilityState(int objectId, bool visible);
+    void nChangeVisibilityState(ObjectTreeItem *item, bool visible);
     void buildColorMap(int rootObjectId);
     int addTopObject(QString name);
 
-        // getters
+    // Given a name, create a new item and assign its item data (if the name is new, create a new item data)
+    ObjectTreeItem *addNewObjectTreeItem(QString name);
+
+    // getters
     BRLCAD::MemoryDatabase* getDatabase() const
     {
 	    return database;
@@ -240,9 +247,32 @@ public:
     QHash<int, VisibilityState> &getObjectVisibility() {
         return objectIdVisibilityStateMap;
     }
+
+    QHash<unsigned int, ObjectTreeItem*> &getItems() {
+        return items;
+    }
+
+    QHash<QString, ObjectTreeItemData*> &getItemsData() {
+        return itemsData;
+    }
 	
 private:
     BRLCAD::MemoryDatabase* database;
+
+    BRLCAD::CommandString* parser;
+
+    class nObjectTreeCallback {
+    public:
+        nObjectTreeCallback(ObjectTree* objectTree) : objectTree(objectTree) {}
+        void operator()(const BRLCAD::Object& object);
+
+    private:
+        void traverseSubTree(const BRLCAD::Combination::ConstTreeNode& node);
+
+        ObjectTree* objectTree = nullptr;
+        ObjectTreeItem* currItem = nullptr;
+        BRLCAD::Combination::ConstTreeNode::Operator currOp = BRLCAD::Combination::ConstTreeNode::Null;
+    };
 	
 	// this class is used for traversing the MemoryDatabase and produce the tree
     class ObjectTreeCallback {

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -205,8 +205,6 @@ public:
 
     unsigned int addTopObject(QString name);
 
-    void printTree(void);
-
     // getters
     BRLCAD::MemoryDatabase* getDatabase() const
     {

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -222,9 +222,9 @@ public:
 private:
     BRLCAD::MemoryDatabase* database;
 
-    class objectTreeCallback {
+    class ObjectTreeCallback {
     public:
-        objectTreeCallback(ObjectTree* objectTree) : objectTree(objectTree) {}
+        ObjectTreeCallback(ObjectTree* objectTree) : objectTree(objectTree) {}
         void operator()(const BRLCAD::Object& object);
 
     private:

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -189,83 +189,28 @@ private:
 };
 
 
-/*
- * Generates and stores the object tree by reading a database.
- * This class is used by ObjectTreeWidget, GeometryRenderer etc. throughout the application a lot.
- * This class also contains several data structures needed for rendering the tree.
- * BRLCAD already provides options for traversing the database.
- * But BRLCAD traverses through the entire bool tree. Also we cannot randomly access nodes in the tree.
- * Therefore in this class we use the BRLCAD methods to copy and create out own tree.
- * 
- *
- * We assign an integer id to each object to identify it. Same object can have multiple ids if they appear
- * multiple times in the tree like all.g\orb and ball.g\orb
- */
-
 class ObjectTree {
 public:
-    enum VisibilityState{
-        Invisible,
-        SomeChildrenVisible,
-        FullyVisible,
-    };
-
     ObjectTree(BRLCAD::MemoryDatabase* database);
 
-    int lastAllocatedId = 0;
+    unsigned int lastAllocatedId = 0;
 
-    unsigned int nLastAllocatedId = 0;
+    void traverseSubTree(ObjectTreeItem *rootOfSubTree, bool traverseRoot, const std::function<bool(ObjectTreeItem*)>& callback);
+    void traverseSubTree(const unsigned rootOfSubTreeId, bool traverseRoot, const std::function<bool(unsigned int)>& callback);
 
-    void traverseSubTree(int rootOfSubTreeId, bool traverseRoot, const std::function<bool(int)>&);
-    void nTraverseSubTree(ObjectTreeItem *rootOfSubTree, bool traverseRoot, const std::function<bool(ObjectTreeItem*)>& callback);
-    void nTraverseSubTree(const unsigned rootOfSubTreeId, bool traverseRoot, const std::function<bool(unsigned int)>& callback);
-
-    void changeVisibilityState(int objectId, bool visible);
-    void nChangeVisibilityState(unsigned int objectId, bool visible);
-    void buildColorMap(int rootObjectId);
-    int addTopObject(QString name);
+    void changeVisibilityState(unsigned int objectId, bool visible);
 
     // Given a name, create a new item and assign its item data (if the name is new, create a new item data)
     ObjectTreeItem *addNewObjectTreeItem(QString name);
+
+    unsigned int addTopObject(QString name);
+
+    void printTree(void);
 
     // getters
     BRLCAD::MemoryDatabase* getDatabase() const
     {
 	    return database;
-    }
-
-    QHash<int, QVector<int>>& getChildren()
-    {
-        return objectIdChildrenObjectIdsMap;
-    }
-
-    QHash<int, int>& getParent()
-    {
-        return objectIdParentObjectIdMap;
-    }
-
-    QHash<int, QString>& getNameMap()
-    {
-        return nameMap;
-    }
-
-    QHash<int, QString>& getFullPathMap()
-    {
-        return fullPathMap;
-    }
-	
-    QHash<int, ColorInfo>& getColorMap()
-    {
-        return colorMap;
-    }
-
-    QSet<int>& getDrawableObjectIds()
-    {
-        return drawableObjectIds;
-    }
-
-    QHash<int, VisibilityState> &getObjectVisibility() {
-        return objectIdVisibilityStateMap;
     }
 
     QHash<unsigned int, ObjectTreeItem*> &getItems() {
@@ -279,11 +224,9 @@ public:
 private:
     BRLCAD::MemoryDatabase* database;
 
-    BRLCAD::CommandString* parser;
-
-    class nObjectTreeCallback {
+    class objectTreeCallback {
     public:
-        nObjectTreeCallback(ObjectTree* objectTree) : objectTree(objectTree) {}
+        objectTreeCallback(ObjectTree* objectTree) : objectTree(objectTree) {}
         void operator()(const BRLCAD::Object& object);
 
     private:
@@ -293,49 +236,8 @@ private:
         ObjectTreeItem* currItem = nullptr;
         BRLCAD::Combination::ConstTreeNode::Operator currOp = BRLCAD::Combination::ConstTreeNode::Null;
     };
-	
-	// this class is used for traversing the MemoryDatabase and produce the tree
-    class ObjectTreeCallback {
-    public:
-        ObjectTreeCallback(ObjectTree* objectTree, QString& objectName, const int& parentObjectId) :
-            objectTree(objectTree),
-            objectName(objectName),
-            parentObjectId(parentObjectId),
-            currentObjectPath(objectTree->fullPathMap[parentObjectId] + "/" + objectName) {}
-        void operator()(const BRLCAD::Object& object);
-    private:
-        int objectId = -1;
-        ObjectTree* objectTree = nullptr;
-        QString objectName;
-        const int& parentObjectId;
-    	QString currentObjectPath;
-        QVector<int>* childrenNames = nullptr;
-        void traverseSubTree(const BRLCAD::Combination::ConstTreeNode& node) const; //traverse the boolean tree of the MemoryDatabase
-    };
 
-    // Stores the object tree in  {parent's object id (key), children's object ids (value)} format
-    QHash<int, QVector<int>>    objectIdChildrenObjectIdsMap;
-
-    // Stores the object tree in  { object id (key), parent's object id (value)} format
-    QHash<int, int>    objectIdParentObjectIdMap;
-
-	// Object id to it's name mapping
-    QHash<int, QString>         nameMap;
-
-    // Object id to it's full path mapping
-    QHash<int, QString>         fullPathMap;
-
-    // Object id to it's full path mapping
-    QHash<int, ColorInfo>         colorMap;
-
-    // Get all objects that are not combinations. (ie. these are also the objects that can be drawn) //todo _GLOBAL?
-    QSet<int>                   drawableObjectIds;
-
-
-    QHash<int, VisibilityState>             objectIdVisibilityStateMap;
-
-
-    // All items (except rootItem)
+    // All items
     QHash<unsigned int, ObjectTreeItem*> items;
 
     // Unique name to item data

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -12,8 +12,6 @@
 #include <set>
 #include <QString>
 #include <brlcad/CommandString/CommandString.h>
-
-
 #include "Utils.h"
 
 
@@ -52,6 +50,7 @@
    So with the use of these 2 classes, we can represent what is SHARED across ALL occurrences in a database
    of an object through ObjectTreeItemData, and what is UNIQUE FOR EACH occurrences in a database of an
    object through ObjectTreeItem */
+
 
 class ObjectTreeItem;
 
@@ -92,6 +91,10 @@ public:
         return isDrawableFlag;
     }
 
+    ColorInfo& getColorInfo(void) {
+        return colorInfo;
+    }
+
 private:
     QVector<ObjectTreeItem *> itemsWithThisData;
 
@@ -100,6 +103,7 @@ private:
 
     bool isAliveFlag = false;
     bool isDrawableFlag = false;
+    ColorInfo colorInfo = {0, 0, 0, false};
 };
 
 
@@ -161,6 +165,10 @@ public:
         return data->isDrawable();
     }
 
+    ColorInfo& getColorInfo(void) {
+        return data->getColorInfo();
+    }
+
     // Setters
     void setParent(ObjectTreeItem *itemParent) {
         parent = itemParent;
@@ -179,6 +187,7 @@ private:
 
     VisibilityState visibilityState = Invisible;
 };
+
 
 /*
  * Generates and stores the object tree by reading a database.

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -196,7 +196,6 @@ public:
     size_t lastAllocatedId = 0;
 
     void traverseSubTree(ObjectTreeItem *rootOfSubTree, const bool traverseRoot, const std::function<bool(ObjectTreeItem*)>& callback);
-    void traverseSubTree(const size_t rootOfSubTreeId, const bool traverseRoot, const std::function<bool(size_t)>& callback);
 
     void changeVisibilityState(size_t objectId, bool visible);
 
@@ -217,6 +216,10 @@ public:
 
     QHash<QString, ObjectTreeItemData*> &getItemsData() {
         return itemsData;
+    }
+
+    ObjectTreeItem* getRootItem() {
+        return getItems()[0];
     }
 	
 private:

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -26,12 +26,21 @@
    ObjectTreeItemData is the representation of an unique object in the database. As such, for example,
    all occurrences in a database of "obj":
        - have the same name,
-       - have the same children (which are treated with the same operations),
-       - are all either drawable or not,
+       - have the same children operations (all children items of an item with this item data will be
+         treated with the same operations),
+       - are all either drawable or not (solid or combination),
        - are all either alive or dead (killed).
 
    ObjectTreeItem is the representation of an object in the database tree. As such, for example, all
    occurrences in a database of "obj":
+       - will have different children items (which share the same item data), for example:
+             obj
+              |_____ u sph1.s  (different item from the other sph1.s, but same item data)
+              |_____ - sph2.s  (different item from the other sph2.s, but same item data)
+             ...
+             obj
+              |_____ u sph1.s  (different item from the other sph1.s, but same item data)
+              |_____ - sph2.s  (different item from the other sph2.s, but same item data)
        - might have a different parent, for example:
              comb1.c
                 |_____ u obj
@@ -50,8 +59,6 @@ class ObjectTreeItem;
 class ObjectTreeItemData {
 public:
     ObjectTreeItemData(QString name) : name(name) {};
-
-    void addChild(ObjectTreeItem *itemParent);
 
     void addOp(BRLCAD::Combination::ConstTreeNode::Operator op);
 
@@ -73,10 +80,6 @@ public:
         return name;
     }
 
-    QVector<ObjectTreeItem *>& getChildren(void) {
-        return children;
-    }
-
     QVector<BRLCAD::Combination::ConstTreeNode::Operator>& getChildrenOps(void) {
         return childrenOps;
     }
@@ -93,7 +96,6 @@ private:
     QVector<ObjectTreeItem *> itemsWithThisData;
 
     QString name;
-    QVector<ObjectTreeItem *> children;
     QVector<BRLCAD::Combination::ConstTreeNode::Operator> childrenOps;
 
     bool isAliveFlag = false;
@@ -109,19 +111,29 @@ public:
         FullyVisible,
     };
 
-    ObjectTreeItem(ObjectTreeItemData* data);
+    ObjectTreeItem(ObjectTreeItemData* data, unsigned int uniqueObjectId);
+
+    void addChild(ObjectTreeItem *itemParent);
 
     bool isRoot(void);
 
     QString getPath(void);
 
     // Getters
+    ObjectTreeItemData *getData(void) {
+        return data;
+    }
+
+    unsigned int getObjectId(void) {
+        return uniqueObjectId;
+    }
+
     ObjectTreeItem *getParent(void) {
         return parent;
     }
 
-    ObjectTreeItemData *getData(void) {
-        return data;
+    QVector<ObjectTreeItem *>& getChildren(void) {
+        return children;
     }
 
     VisibilityState getVisibilityState(void) {
@@ -135,10 +147,6 @@ public:
 
     QString getName(void) {
         return data->getName();
-    }
-
-    QVector<ObjectTreeItem *>& getChildren(void) {
-        return data->getChildren();
     }
 
     QVector<BRLCAD::Combination::ConstTreeNode::Operator>& getChildrenOps(void) {
@@ -164,8 +172,10 @@ public:
 
 private:
     ObjectTreeItemData *data;
+    unsigned int uniqueObjectId;
 
     ObjectTreeItem *parent;
+    QVector<ObjectTreeItem *> children;
 
     VisibilityState visibilityState = Invisible;
 };
@@ -199,9 +209,10 @@ public:
 
     void traverseSubTree(int rootOfSubTreeId, bool traverseRoot, const std::function<bool(int)>&);
     void nTraverseSubTree(ObjectTreeItem *rootOfSubTree, bool traverseRoot, const std::function<bool(ObjectTreeItem*)>& callback);
+    void nTraverseSubTree(const unsigned rootOfSubTreeId, bool traverseRoot, const std::function<bool(unsigned int)>& callback);
 
     void changeVisibilityState(int objectId, bool visible);
-    void nChangeVisibilityState(ObjectTreeItem *item, bool visible);
+    void nChangeVisibilityState(unsigned int objectId, bool visible);
     void buildColorMap(int rootObjectId);
     int addTopObject(QString name);
 

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -115,7 +115,7 @@ public:
         FullyVisible,
     };
 
-    ObjectTreeItem(ObjectTreeItemData* data, unsigned int uniqueObjectId);
+    ObjectTreeItem(ObjectTreeItemData* data, size_t uniqueObjectId);
 
     void addChild(ObjectTreeItem *itemParent);
 
@@ -128,7 +128,7 @@ public:
         return data;
     }
 
-    unsigned int getObjectId(void) {
+    size_t getObjectId(void) {
         return uniqueObjectId;
     }
 
@@ -180,7 +180,7 @@ public:
 
 private:
     ObjectTreeItemData *data;
-    unsigned int uniqueObjectId;
+    size_t uniqueObjectId;
 
     ObjectTreeItem *parent;
     QVector<ObjectTreeItem *> children;
@@ -193,17 +193,17 @@ class ObjectTree {
 public:
     ObjectTree(BRLCAD::MemoryDatabase* database);
 
-    unsigned int lastAllocatedId = 0;
+    size_t lastAllocatedId = 0;
 
-    void traverseSubTree(ObjectTreeItem *rootOfSubTree, bool traverseRoot, const std::function<bool(ObjectTreeItem*)>& callback);
-    void traverseSubTree(const unsigned rootOfSubTreeId, bool traverseRoot, const std::function<bool(unsigned int)>& callback);
+    void traverseSubTree(ObjectTreeItem *rootOfSubTree, const bool traverseRoot, const std::function<bool(ObjectTreeItem*)>& callback);
+    void traverseSubTree(const size_t rootOfSubTreeId, const bool traverseRoot, const std::function<bool(size_t)>& callback);
 
-    void changeVisibilityState(unsigned int objectId, bool visible);
+    void changeVisibilityState(size_t objectId, bool visible);
 
     // Given a name, create a new item and assign its item data (if the name is new, create a new item data)
     ObjectTreeItem *addNewObjectTreeItem(QString name);
 
-    unsigned int addTopObject(QString name);
+    size_t addTopObject(QString name);
 
     // getters
     BRLCAD::MemoryDatabase* getDatabase() const
@@ -211,7 +211,7 @@ public:
 	    return database;
     }
 
-    QHash<unsigned int, ObjectTreeItem*> &getItems() {
+    QHash<size_t, ObjectTreeItem*> &getItems() {
         return items;
     }
 
@@ -236,7 +236,7 @@ private:
     };
 
     // All items
-    QHash<unsigned int, ObjectTreeItem*> items;
+    QHash<size_t, ObjectTreeItem*> items;
 
     // Unique name to item data
     QHash<QString, ObjectTreeItemData*> itemsData;

--- a/include/ObjectTreeRowButtons.h
+++ b/include/ObjectTreeRowButtons.h
@@ -30,17 +30,17 @@ private:
 
     QImage iconCenter;
 
-    int objectId = 0;
+    unsigned int objectId = 0;
     ObjectTree *objectTree;
-    ObjectTree::VisibilityState visibilityState = ObjectTree::Invisible;
+    ObjectTreeItem::VisibilityState visibilityState = ObjectTreeItem::Invisible;
     static const int margin = 0;
     const char *const visibilityIconFilePath = ":/icons/baseline_visibility_black_18dp.png";
     const char *const centerIconFilePath = ":/icons/baseline_center_focus_strong_black_18dp.png";
     Q_DISABLE_COPY(ObjectTreeRowButtons)
 
 signals:
-    void visibilityButtonClicked(int objectId);
-    void centerButtonClicked(int objectId);
+    void visibilityButtonClicked(unsigned int objectId);
+    void centerButtonClicked(unsigned int objectId);
 
 };
 

--- a/include/ObjectTreeRowButtons.h
+++ b/include/ObjectTreeRowButtons.h
@@ -30,7 +30,7 @@ private:
 
     QImage iconCenter;
 
-    unsigned int objectId = 0;
+    size_t objectId = 0;
     ObjectTree *objectTree;
     ObjectTreeItem::VisibilityState visibilityState = ObjectTreeItem::Invisible;
     static const int margin = 0;
@@ -39,8 +39,8 @@ private:
     Q_DISABLE_COPY(ObjectTreeRowButtons)
 
 signals:
-    void visibilityButtonClicked(unsigned int objectId);
-    void centerButtonClicked(unsigned int objectId);
+    void visibilityButtonClicked(size_t objectId);
+    void centerButtonClicked(size_t objectId);
 
 };
 

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -55,8 +55,8 @@ private:
     QColor colorInvisible;
 
 signals:
-    void visibilityButtonClicked(int objectId);
-    void selectionChanged(int objectId);
+    void visibilityButtonClicked(unsigned int objectId);
+    void selectionChanged(unsigned int objectId);
 
 
 };

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -42,21 +42,21 @@ class ObjectTreeWidget : public QTreeWidget {
 public:
     explicit ObjectTreeWidget(Document *objectTree,   QWidget *parent = nullptr);
     void refreshItemTextColors();
-    const QHash<unsigned int, QTreeWidgetItem *> &getObjectIdTreeWidgetItemMap() const;
-    void build(const unsigned int objectId, QTreeWidgetItem* parent = nullptr);
+    const QHash<size_t, QTreeWidgetItem *> &getObjectIdTreeWidgetItemMap() const;
+    void build(const size_t objectId, QTreeWidgetItem* parent = nullptr);
     void select(QString selected);
     void setTextColor();
 private:
     Document* document;
-    QHash <unsigned int, QTreeWidgetItem*> objectIdTreeWidgetItemMap;
+    QHash <size_t, QTreeWidgetItem*> objectIdTreeWidgetItemMap;
 
     QColor colorFullVisible;
     QColor colorSomeChildrenVisible;
     QColor colorInvisible;
 
 signals:
-    void visibilityButtonClicked(unsigned int objectId);
-    void selectionChanged(unsigned int objectId);
+    void visibilityButtonClicked(size_t objectId);
+    void selectionChanged(size_t objectId);
 
 
 };

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -42,13 +42,13 @@ class ObjectTreeWidget : public QTreeWidget {
 public:
     explicit ObjectTreeWidget(Document *objectTree,   QWidget *parent = nullptr);
     void refreshItemTextColors();
-    const QHash<int, QTreeWidgetItem *> &getObjectIdTreeWidgetItemMap() const;
-    void build(int objectId, QTreeWidgetItem* parent = nullptr);
+    const QHash<unsigned int, QTreeWidgetItem *> &getObjectIdTreeWidgetItemMap() const;
+    void build(const unsigned int objectId, QTreeWidgetItem* parent = nullptr);
     void select(QString selected);
     void setTextColor();
 private:
     Document* document;
-    QHash <int, QTreeWidgetItem*> objectIdTreeWidgetItemMap;
+    QHash <unsigned int, QTreeWidgetItem*> objectIdTreeWidgetItemMap;
 
     QColor colorFullVisible;
     QColor colorSomeChildrenVisible;

--- a/include/OrthographicCamera.h
+++ b/include/OrthographicCamera.h
@@ -77,7 +77,7 @@ public:
 
     void autoview();
 
-    void centerView(unsigned int objectId);
+    void centerView(size_t objectId);
 
     void centerToCurrentSelection();
 

--- a/include/OrthographicCamera.h
+++ b/include/OrthographicCamera.h
@@ -77,7 +77,7 @@ public:
 
     void autoview();
 
-    void centerView(int objectId);
+    void centerView(unsigned int objectId);
 
     void centerToCurrentSelection();
 

--- a/include/Properties.h
+++ b/include/Properties.h
@@ -17,7 +17,7 @@ class TypeSpecificProperties;
 class Properties: public QVBoxWidget{
 public:
     explicit Properties(Document & document);
-    void bindObject(const unsigned int objectId);
+    void bindObject(const size_t objectId);
     void rewriteObjectNameAndType();
 
 private:

--- a/include/Properties.h
+++ b/include/Properties.h
@@ -17,7 +17,7 @@ class TypeSpecificProperties;
 class Properties: public QVBoxWidget{
 public:
     explicit Properties(Document & document);
-    void bindObject(const int objectId);
+    void bindObject(const unsigned int objectId);
     void rewriteObjectNameAndType();
 
 private:

--- a/include/TypeSpecificProperties.h
+++ b/include/TypeSpecificProperties.h
@@ -10,7 +10,7 @@
 
 class TypeSpecificProperties: public QVBoxWidget {
 public:
-    TypeSpecificProperties(Document &document, BRLCAD::Object *object, const int i);
+    TypeSpecificProperties(Document &document, BRLCAD::Object *object, const unsigned int objectId);
 
 protected:
     Document& document;

--- a/include/TypeSpecificProperties.h
+++ b/include/TypeSpecificProperties.h
@@ -10,7 +10,7 @@
 
 class TypeSpecificProperties: public QVBoxWidget {
 public:
-    TypeSpecificProperties(Document &document, BRLCAD::Object *object, const unsigned int objectId);
+    TypeSpecificProperties(Document &document, BRLCAD::Object *object, const size_t objectId);
 
 protected:
     Document& document;

--- a/include/ViewportManager.h
+++ b/include/ViewportManager.h
@@ -41,12 +41,12 @@ public:
     void setLineAttr(int width, int style);
     void setLineStyle(int style);
     void setLineWidth(int width);
-    unsigned int genDLists(size_t range);
-    void beginDList(unsigned int list);
+    size_t genDLists(size_t range);
+    void beginDList(size_t list);
     void endDList();
-    void drawDList(unsigned int list);
-    void freeDLists(unsigned int list, int range);
-    GLboolean isDListValid(unsigned int list);
+    void drawDList(size_t list);
+    void freeDLists(size_t list, size_t range);
+    GLboolean isDListValid(size_t list);
     void saveState();
     void restoreState();
     void drawBegin();

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -37,14 +37,11 @@ void Document::modifyObject(BRLCAD::Object *newObject) {
     modified = true;
     database->Set(*newObject);
     QString objectName = newObject->Name();
-    getObjectTree()->traverseSubTree(0,false,[this, objectName]
-    (int objectId){
-        if (getObjectTree()->getNameMap()[objectId] == objectName){
+    getObjectTree()->traverseSubTree(0, false, [this, objectName](unsigned int objectId) {
+        if (getObjectTree()->getItems()[objectId]->getName() == objectName)
             geometryRenderer->clearObject(objectId);
-        }
         return true;
-    }
-    );
+    });
     geometryRenderer->refreshForVisibilityAndSolidChanges();
     for (Viewport * display : displayGrid->getViewports())display->forceRerenderFrame();
 }
@@ -56,8 +53,8 @@ bool Document::isModified() {
 bool Document::AddObject(const BRLCAD::Object& object, const bool isVisible) {
     modified = true;
     return database->Add(object);
-    unsigned int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-    getObjectTree()->nChangeVisibilityState(objectId, isVisible);
+    unsigned int objectId = getObjectTree()->addTopObject(QString(object.Name()));
+    getObjectTree()->changeVisibilityState(objectId, isVisible);
     getObjectTreeWidget()->build(objectId);
     getObjectTreeWidget()->refreshItemTextColors();
     getGeometryRenderer()->refreshForVisibilityAndSolidChanges();

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -53,9 +53,15 @@ bool Document::isModified() {
     return modified;
 }
 
-bool Document::Add(const BRLCAD::Object& object) {
+bool Document::AddObject(const BRLCAD::Object& object, const bool isVisible) {
     modified = true;
     return database->Add(object);
+    unsigned int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
+    getObjectTree()->nChangeVisibilityState(objectId, isVisible);
+    getObjectTreeWidget()->build(objectId);
+    getObjectTreeWidget()->refreshItemTextColors();
+    getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
+    getViewportGrid()->forceRerenderAllViewports();
 }
 
 bool Document::Save(const char* fileName) {

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -37,9 +37,9 @@ void Document::modifyObject(BRLCAD::Object *newObject) {
     modified = true;
     database->Set(*newObject);
     QString objectName = newObject->Name();
-    getObjectTree()->traverseSubTree(0, false, [this, objectName](size_t objectId) {
-        if (getObjectTree()->getItems()[objectId]->getName() == objectName)
-            geometryRenderer->clearObject(objectId);
+    getObjectTree()->traverseSubTree(getObjectTree()->getRootItem(), false, [this, objectName](ObjectTreeItem* currItem) {
+        if (currItem->getName() == objectName)
+            geometryRenderer->clearObject(currItem->getObjectId());
         return true;
     });
     geometryRenderer->refreshForVisibilityAndSolidChanges();

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -51,14 +51,17 @@ bool Document::isModified() {
 }
 
 bool Document::AddObject(const BRLCAD::Object& object, const bool isVisible) {
-    modified = true;
-    return database->Add(object);
-    unsigned int objectId = getObjectTree()->addTopObject(QString(object.Name()));
-    getObjectTree()->changeVisibilityState(objectId, isVisible);
-    getObjectTreeWidget()->build(objectId);
-    getObjectTreeWidget()->refreshItemTextColors();
-    getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-    getViewportGrid()->forceRerenderAllViewports();
+    bool ret = database->Add(object);
+    if (ret) {
+        modified = true;
+        unsigned int objectId = getObjectTree()->addTopObject(QString(object.Name()));
+        getObjectTree()->changeVisibilityState(objectId, isVisible);
+        getObjectTreeWidget()->build(objectId);
+        getObjectTreeWidget()->refreshItemTextColors();
+        getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
+        getViewportGrid()->forceRerenderAllViewports();
+    }
+    return ret;
 }
 
 bool Document::Save(const char* fileName) {

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -37,7 +37,7 @@ void Document::modifyObject(BRLCAD::Object *newObject) {
     modified = true;
     database->Set(*newObject);
     QString objectName = newObject->Name();
-    getObjectTree()->traverseSubTree(0, false, [this, objectName](unsigned int objectId) {
+    getObjectTree()->traverseSubTree(0, false, [this, objectName](size_t objectId) {
         if (getObjectTree()->getItems()[objectId]->getName() == objectName)
             geometryRenderer->clearObject(objectId);
         return true;
@@ -54,7 +54,7 @@ bool Document::AddObject(const BRLCAD::Object& object, const bool isVisible) {
     bool ret = database->Add(object);
     if (ret) {
         modified = true;
-        unsigned int objectId = getObjectTree()->addTopObject(QString(object.Name()));
+        size_t objectId = getObjectTree()->addTopObject(QString(object.Name()));
         getObjectTree()->changeVisibilityState(objectId, isVisible);
         getObjectTreeWidget()->build(objectId);
         getObjectTreeWidget()->refreshItemTextColors();

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -181,17 +181,6 @@ void ObjectTree::traverseSubTree(ObjectTreeItem *rootOfSubTree, bool traverseRoo
 }
 
 
-void ObjectTree::traverseSubTree(const size_t rootOfSubTreeId, bool traverseRoot, const std::function<bool(size_t)>& callback) {
-	ObjectTreeItem *item = getItems()[rootOfSubTreeId];
-    if (traverseRoot) callback(item->getObjectId());
-	for (ObjectTreeItem *itemChild : item->getChildren()) {
-        const size_t childId = itemChild->getObjectId();
-		if (!callback(childId)) continue;
-		if (!itemChild->getChildren().empty()) traverseSubTree(childId, false, callback);
-	}
-}
-
-
 void ObjectTree::changeVisibilityState(size_t objectId, bool visible) {
     ObjectTreeItem *item = getItems()[objectId];
     if (visible) {

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -68,7 +68,7 @@ QString ObjectTreeItem::getPath(void) {
 
 // ---------- OBJECT TREE CALLBACK ----------
 
-/* Warning: objectTreeCallback() (used to construct the object tree of a database) assumes that in a database
+/* Warning: ObjectTreeCallback() (used to construct the object tree of a database) assumes that in a database
    all occurrences of a certain object (with a unique name) must have all the same children and operations.
    This means that, if there was a situation where the same combination appears more times in the database with
    different children/operations, for example:
@@ -77,7 +77,7 @@ QString ObjectTreeItem::getPath(void) {
                |__________ - "sph2.s"                     |__________ u "sph2.s"
    then the tree would be constructed so that the "combination.c" item data will have the children and operations
    equal to that of the first occurrence that it meets while creating the tree */
-void ObjectTree::objectTreeCallback::operator()(const BRLCAD::Object& object) {
+void ObjectTree::ObjectTreeCallback::operator()(const BRLCAD::Object& object) {
     currItem = objectTree->getItems()[objectTree->lastAllocatedId];
 
     // If the object is a combination, iter through its children, else it means that it is drawable
@@ -102,7 +102,7 @@ void ObjectTree::objectTreeCallback::operator()(const BRLCAD::Object& object) {
 }
 
 
-void ObjectTree::objectTreeCallback::traverseSubTree(const BRLCAD::Combination::ConstTreeNode& node) {
+void ObjectTree::ObjectTreeCallback::traverseSubTree(const BRLCAD::Combination::ConstTreeNode& node) {
 	switch (node.Operation()) {
         // If Union/Intersection/Subtraction/ExclusiveOr, access children
         case BRLCAD::Combination::ConstTreeNode::Union:
@@ -130,7 +130,7 @@ void ObjectTree::objectTreeCallback::traverseSubTree(const BRLCAD::Combination::
             if (!currItem->isAlive())
                 currItem->getData()->addOp(currOp);
             // Get new object and loop through his children with callback
-            objectTreeCallback callback(objectTree);
+            ObjectTreeCallback callback(objectTree);
             objectTree->getDatabase()->Get(node.Name(), callback);
 	}
 }
@@ -253,7 +253,7 @@ unsigned int ObjectTree::addTopObject(QString name) {
     topLevelItem->setParent(rootItem);
     rootItem->addChild(topLevelItem);
     // Get top level object and loop through his children with callback
-    objectTreeCallback callback(this);
+    ObjectTreeCallback callback(this);
     database->Get(name.toUtf8(), callback);
 	return lastAllocatedId;
 }

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -43,7 +43,7 @@ void ObjectTreeItemData::addOp(BRLCAD::Combination::ConstTreeNode::Operator op) 
 
 // ---------- OBJECT TREE ITEM ----------
 
-ObjectTreeItem::ObjectTreeItem(ObjectTreeItemData* data, unsigned int uniqueObjectId) : data(data), uniqueObjectId(uniqueObjectId) {
+ObjectTreeItem::ObjectTreeItem(ObjectTreeItemData* data, size_t uniqueObjectId) : data(data), uniqueObjectId(uniqueObjectId) {
     // When I create an item, I also need to give the item to the item data that it references 
     getItemsWithSameData().append(this);
 }
@@ -181,7 +181,7 @@ void ObjectTree::traverseSubTree(ObjectTreeItem *rootOfSubTree, bool traverseRoo
 }
 
 
-void ObjectTree::traverseSubTree(const unsigned rootOfSubTreeId, bool traverseRoot, const std::function<bool(unsigned int)>& callback) {
+void ObjectTree::traverseSubTree(const size_t rootOfSubTreeId, bool traverseRoot, const std::function<bool(size_t)>& callback) {
 	ObjectTreeItem *item = getItems()[rootOfSubTreeId];
     if (traverseRoot) callback(item->getObjectId());
 	for (ObjectTreeItem *itemChild : item->getChildren()) {
@@ -192,7 +192,7 @@ void ObjectTree::traverseSubTree(const unsigned rootOfSubTreeId, bool traverseRo
 }
 
 
-void ObjectTree::changeVisibilityState(unsigned int objectId, bool visible) {
+void ObjectTree::changeVisibilityState(size_t objectId, bool visible) {
     ObjectTreeItem *item = getItems()[objectId];
     if (visible) {
         item->setVisibilityState(ObjectTreeItem::FullyVisible);
@@ -246,7 +246,7 @@ void ObjectTree::changeVisibilityState(unsigned int objectId, bool visible) {
 }
 
 
-unsigned int ObjectTree::addTopObject(QString name) {
+size_t ObjectTree::addTopObject(QString name) {
     ObjectTreeItem *topLevelItem = addNewObjectTreeItem(name);
     ObjectTreeItem *rootItem = getItems()[0];
     topLevelItem->setParent(rootItem);
@@ -260,7 +260,7 @@ unsigned int ObjectTree::addTopObject(QString name) {
 
 // This method comes from the old ObjectTree (before PR#66)
 /*void ObjectTree::buildColorMap(int rootObjectId) {
-	traverseSubTree(rootObjectId,true,[&](unsigned int objectId){
+	traverseSubTree(rootObjectId,true,[&](size_t objectId){
 		if (objectId == 0)return true;
 		const QString objectName = fullPathMap[objectId];
 		const QByteArray &name = objectName.toUtf8();

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -138,7 +138,7 @@ void ObjectTree::objectTreeCallback::traverseSubTree(const BRLCAD::Combination::
 
 // ---------- OBJECT TREE ----------
 
-ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database, Document *document) : database(database), document(document) {
+ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database) : database(database) {
     // Create root item and root item data (parent = nullptr, empty name, objectId = 0)
     QString rootName = "";
     ObjectTreeItemData *rootItemData = new ObjectTreeItemData(rootName);
@@ -154,8 +154,6 @@ ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database, Document *document) : d
         addTopObject(QString(it.Name()));
         ++it;
     }
-
-    printTree();
 }
 
 ObjectTreeItem *ObjectTree::addNewObjectTreeItem(QString name) {
@@ -172,18 +170,6 @@ ObjectTreeItem *ObjectTree::addNewObjectTreeItem(QString name) {
     ObjectTreeItem *newItem = new ObjectTreeItem(newItemData, ++lastAllocatedId);
     getItems().insert(lastAllocatedId, newItem);
     return newItem;
-}
-
-
-void ObjectTree::printTree(void) {
-    // Print tree of new method
-    for (ObjectTreeItem *it : getItems()) {
-        qDebug() << it->getObjectId() << "\t->" << it->getPath() << "\n\t\tisAlive =" << it->isAlive() << ", isDrawable =" << it->isDrawable() << ", visibilityState =" << it->getVisibilityState();
-        for (ObjectTreeItem *itChild : it->getChildren())
-            qDebug() << "\t\t" << itChild->getPath();
-        for (BRLCAD::Combination::ConstTreeNode::Operator itChildOp : it->getChildrenOps())
-            qDebug() << "\t\t" << itChildOp;
-    }
 }
 
 
@@ -258,8 +244,6 @@ void ObjectTree::changeVisibilityState(unsigned int objectId, bool visible) {
             return true;
         });
     }
-
-    printTree();
 }
 
 

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -30,6 +30,41 @@
 #include "ObjectTree.h"
 #include <QStandardItemModel>
 #include "brlcad/Database/MemoryDatabase.h"
+#include <QString>
+#include <brlcad/CommandString/CommandString.h>
+
+
+// ---------- OBJECT TREE ITEM DATA ----------
+
+void ObjectTreeItemData::addChild(ObjectTreeItem *itemParent) {
+    children.append(itemParent);
+}
+
+void ObjectTreeItemData::addOp(BRLCAD::Combination::ConstTreeNode::Operator op) {
+    childrenOps.append(op);
+}
+
+
+// ---------- OBJECT TREE ITEM ----------
+
+ObjectTreeItem::ObjectTreeItem(ObjectTreeItemData* data) : data(data) {
+    // When I create an item, I also need to give the item to the item data that it references 
+    getItemsWithSameData().append(this);
+}
+
+bool ObjectTreeItem::isRoot(void) {
+    if (getParent() == nullptr)
+        return true;
+    return false;
+}
+
+QString ObjectTreeItem::getPath(void) {
+    if (isRoot())
+        return "";
+    return getParent()->getPath() + "/" + getName();
+
+}
+
 
 
 void ObjectTree::ObjectTreeCallback::operator()(const BRLCAD::Object& object)
@@ -77,6 +112,7 @@ void ObjectTree::ObjectTreeCallback::traverseSubTree(const BRLCAD::Combination::
 	}
 }
 
+// ---------- OBJECT TREE ----------
 
 int ObjectTree::addTopObject(QString name) {
 	QVector<int>* childrenNames = &getChildren()[0];

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -60,7 +60,7 @@ bool ObjectTreeItem::isRoot(void) {
 
 QString ObjectTreeItem::getPath(void) {
     if (isRoot())
-        return "";
+        return QString("");
     return getParent()->getPath() + "/" + getName();
 
 }
@@ -207,10 +207,13 @@ ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database) : database(database) {
     parser = new BRLCAD::CommandString(*database);
 
     // Create root item and root item data (root has parent nullptr and empty name)
-    ObjectTreeItem *rootItem = addNewObjectTreeItem(QString(""));
+    QString rootName = ""; 
+    ObjectTreeItemData *rootItemData = new ObjectTreeItemData(rootName);
+    itemsData.insert(rootName, rootItemData);
+    ObjectTreeItem *rootItem = new ObjectTreeItem(rootItemData);
+    items.insert(0, rootItem);
     rootItem->getData()->setIsAliveFlag(true);
     rootItem->setParent(nullptr);
-    --nLastAllocatedId;
 
     // Loop through all top level objects
 	it = database->FirstTopObject();

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -185,7 +185,7 @@ void ObjectTree::traverseSubTree(const size_t rootOfSubTreeId, bool traverseRoot
 	ObjectTreeItem *item = getItems()[rootOfSubTreeId];
     if (traverseRoot) callback(item->getObjectId());
 	for (ObjectTreeItem *itemChild : item->getChildren()) {
-        const unsigned childId = itemChild->getObjectId();
+        const size_t childId = itemChild->getObjectId();
 		if (!callback(childId)) continue;
 		if (!itemChild->getChildren().empty()) traverseSubTree(childId, false, callback);
 	}

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -80,9 +80,15 @@ void ObjectTree::nObjectTreeCallback::operator()(const BRLCAD::Object& object) {
     currItem = objectTree->getItems()[objectTree->nLastAllocatedId];
 
     // If the object is a combination, iter through its children, else it means that it is drawable
-	if (const BRLCAD::Combination* combination = dynamic_cast<const BRLCAD::Combination*>(&object)) {
-		traverseSubTree(combination->Tree());
-	} else
+    if (const BRLCAD::Combination* combination = dynamic_cast<const BRLCAD::Combination*>(&object)) {
+        if (combination->HasColor()) {
+            currItem->getColorInfo().red = combination->Red();
+            currItem->getColorInfo().green = combination->Green();
+            currItem->getColorInfo().blue = combination->Blue();
+            currItem->getColorInfo().hasColor = true;
+        }
+        traverseSubTree(combination->Tree());
+    } else
         currItem->getData()->setIsDrawableFlag(true);
 
     /* The fact that I am in this function in the first place means that the item data exists.

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -32,7 +32,6 @@
 #include "brlcad/Database/MemoryDatabase.h"
 #include <QString>
 #include <brlcad/CommandString/CommandString.h>
-#include <QDebug>
 
 
 // ---------- OBJECT TREE ITEM DATA ----------

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -258,6 +258,7 @@ unsigned int ObjectTree::addTopObject(QString name) {
 }
 
 
+// This method comes from the old ObjectTree (before PR#66)
 /*void ObjectTree::buildColorMap(int rootObjectId) {
 	traverseSubTree(rootObjectId,true,[&](unsigned int objectId){
 		if (objectId == 0)return true;

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -253,7 +253,7 @@ void MainWindow::prepareUi() {
     connect(relativeMoveAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        size_t objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         MatrixTransformWidget * matrixTransformWidget = new MatrixTransformWidget(documents[activeDocumentId],objectId, MatrixTransformWidget::Translate);
     });
     editMenu->addAction(relativeMoveAct);
@@ -263,7 +263,7 @@ void MainWindow::prepareUi() {
     connect(relativeScaleAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        size_t objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         MatrixTransformWidget * matrixTransformWidget = new MatrixTransformWidget(documents[activeDocumentId],objectId, MatrixTransformWidget::Scale);
     });
     editMenu->addAction(relativeScaleAct);
@@ -273,7 +273,7 @@ void MainWindow::prepareUi() {
     connect(relativeRotateAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        size_t objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         MatrixTransformWidget * matrixTransformWidget = new MatrixTransformWidget(documents[activeDocumentId],objectId, MatrixTransformWidget::Rotate);
     });
     editMenu->addAction(relativeRotateAct);
@@ -332,7 +332,7 @@ void MainWindow::prepareUi() {
     connect(centerViewAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        size_t objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         documents[activeDocumentId]->getViewport()->getCamera()->centerView(objectId);
     });
     viewMenu->addAction(centerViewAct);
@@ -880,7 +880,7 @@ void MainWindow::tabCloseRequested(const int i)
     }
 }
 
-void MainWindow::objectTreeWidgetSelectionChanged(unsigned int objectId) {
+void MainWindow::objectTreeWidgetSelectionChanged(size_t objectId) {
     documents[activeDocumentId]->getProperties()->bindObject(objectId);
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -253,7 +253,7 @@ void MainWindow::prepareUi() {
     connect(relativeMoveAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         MatrixTransformWidget * matrixTransformWidget = new MatrixTransformWidget(documents[activeDocumentId],objectId, MatrixTransformWidget::Translate);
     });
     editMenu->addAction(relativeMoveAct);
@@ -263,7 +263,7 @@ void MainWindow::prepareUi() {
     connect(relativeScaleAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         MatrixTransformWidget * matrixTransformWidget = new MatrixTransformWidget(documents[activeDocumentId],objectId, MatrixTransformWidget::Scale);
     });
     editMenu->addAction(relativeScaleAct);
@@ -273,7 +273,7 @@ void MainWindow::prepareUi() {
     connect(relativeRotateAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         MatrixTransformWidget * matrixTransformWidget = new MatrixTransformWidget(documents[activeDocumentId],objectId, MatrixTransformWidget::Rotate);
     });
     editMenu->addAction(relativeRotateAct);
@@ -332,7 +332,7 @@ void MainWindow::prepareUi() {
     connect(centerViewAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
         if (documents[activeDocumentId]->getObjectTreeWidget()->currentItem() == nullptr) return;
-        int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
+        unsigned int objectId = documents[activeDocumentId]->getObjectTreeWidget()->currentItem()->data(0, Qt::UserRole).toInt();
         documents[activeDocumentId]->getViewport()->getCamera()->centerView(objectId);
     });
     viewMenu->addAction(centerViewAct);
@@ -880,7 +880,7 @@ void MainWindow::tabCloseRequested(const int i)
     }
 }
 
-void MainWindow::objectTreeWidgetSelectionChanged(int objectId) {
+void MainWindow::objectTreeWidgetSelectionChanged(unsigned int objectId) {
     documents[activeDocumentId]->getProperties()->bindObject(objectId);
 }
 

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -127,198 +127,121 @@ void MainWindow::prepareUi() {
     QAction* createArb8Act = new QAction(tr("Arb8"), this);
     connect(createArb8Act, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Arb8 * object = new BRLCAD::Arb8();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createArb8Act);
 
     QAction* createConeAct = new QAction(tr("Cone"), this);
     connect(createConeAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Cone * object = new BRLCAD::Cone();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createConeAct);
 
     QAction* createEllipsoidAct = new QAction(tr("Ellipsoid"), this);
     connect(createEllipsoidAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Ellipsoid * object = new BRLCAD::Ellipsoid();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createEllipsoidAct);
 
     QAction* createEllipticalTorusAct = new QAction(tr("Elliptical Torus"), this);
     connect(createEllipticalTorusAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::EllipticalTorus * object = new BRLCAD::EllipticalTorus();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createEllipticalTorusAct);
 
     QAction* createHalfspaceAct = new QAction(tr("Halfspace"), this);
     connect(createHalfspaceAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Halfspace * object = new BRLCAD::Halfspace();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createHalfspaceAct);
 
     QAction* createHyperbolicCylinderAct = new QAction(tr("Hyperbolic Cylinder"), this);
     connect(createHyperbolicCylinderAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::HyperbolicCylinder * object = new BRLCAD::HyperbolicCylinder();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createHyperbolicCylinderAct);
 
     QAction* createHyperboloidAct = new QAction(tr("Hyperboloid"), this);
     connect(createHyperboloidAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Hyperboloid * object = new BRLCAD::Hyperboloid();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createHyperboloidAct);
 
     QAction* createParabolicCylinderAct = new QAction(tr("Parabolic Cylinder"), this);
     connect(createParabolicCylinderAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::ParabolicCylinder * object = new BRLCAD::ParabolicCylinder();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createParabolicCylinderAct);
 
     QAction* createParaboloidAct = new QAction(tr("Paraboloid"), this);
     connect(createParaboloidAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Paraboloid * object = new BRLCAD::Paraboloid();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createParaboloidAct);
 
     QAction* createParticleAct = new QAction(tr("Particle"), this);
     connect(createParticleAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Particle * object = new BRLCAD::Particle();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createParticleAct);
 
     QAction* createTorusAct = new QAction(tr("Torus"), this);
     connect(createTorusAct, &QAction::triggered, this, [this]() {
         if (activeDocumentId == -1) return;
-
         QString name;
         if (!getObjectNameFromUser(this, *documents[activeDocumentId], name)) return;
         BRLCAD::Torus * object = new BRLCAD::Torus();
         object->SetName(name.toUtf8());
-        documents[activeDocumentId]->Add(*object);
-        int objectId = documents[activeDocumentId]->getObjectTree()->addTopObject(name);
-        documents[activeDocumentId]->getObjectTree()->changeVisibilityState(objectId, true);
-        documents[activeDocumentId]->getObjectTreeWidget()->build(objectId);
-        documents[activeDocumentId]->getObjectTreeWidget()->refreshItemTextColors();
-        documents[activeDocumentId]->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-        documents[activeDocumentId]->getViewportGrid()->forceRerenderAllViewports();
+        documents[activeDocumentId]->AddObject(*object, true);
     });
     createMenu->addAction(createTorusAct);
 

--- a/src/gui/MatrixTransformWidget.cpp
+++ b/src/gui/MatrixTransformWidget.cpp
@@ -10,8 +10,9 @@ MatrixTransformWidget::MatrixTransformWidget(Document *document, int childObject
         : DataRow(3, true) {
     setWindowFlags( Qt::Window| Qt::WindowCloseButtonHint);
     setAttribute( Qt::WA_QuitOnClose, false );
-    QString parentObjectName = document->getObjectTree()->getNameMap()[document->getObjectTree()->getParent()[childObjectId]];
-    QString childNodeName = document->getObjectTree()->getNameMap()[childObjectId];
+    ObjectTreeItem *childItem = document->getObjectTree()->getItems()[childObjectId];
+    QString childNodeName = childItem->getName();
+    QString parentObjectName = childItem->getParent()->getName();
     setWindowTitle(childNodeName);
     if (parentObjectName == ""){
         QMessageBox::information(this, "Can't Transform Top Object", "You cannot transform top objects", QMessageBox::Ok);

--- a/src/gui/MatrixTransformWidget.cpp
+++ b/src/gui/MatrixTransformWidget.cpp
@@ -4,9 +4,9 @@
 #include <QMessageBox>
 #include "MatrixTransformWidget.h"
 
-QHash<int,QWidget*> MatrixTransformWidget::widgets;
+QHash<size_t,QWidget*> MatrixTransformWidget::widgets;
 
-MatrixTransformWidget::MatrixTransformWidget(Document *document, int childObjectId, TransformType transformType)
+MatrixTransformWidget::MatrixTransformWidget(Document *document, size_t childObjectId, TransformType transformType)
         : DataRow(3, true) {
     setWindowFlags( Qt::Window| Qt::WindowCloseButtonHint);
     setAttribute( Qt::WA_QuitOnClose, false );

--- a/src/gui/ObjectTreeRowButtons.cpp
+++ b/src/gui/ObjectTreeRowButtons.cpp
@@ -100,8 +100,9 @@ QSize ObjectTreeRowButtons::sizeHint(const QStyleOptionViewItem &option, const Q
 }
 
 bool ObjectTreeRowButtons::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) {
-    objectId = index.data(Qt::UserRole).toInt();
-    visibilityState = objectTree->getItems()[objectId]->getVisibilityState();
+    objectId = index.data(Qt::UserRole).toULongLong();
+    ObjectTreeItem *objTreeItem = objectTree->getItems()[objectId];
+    visibilityState = objTreeItem->getVisibilityState();
     QRect visibilityIconRect = iconFullVisible.rect().translated(visibilityIconPosition(option));
     QRect centerIconRect = iconFullVisible.rect().translated(centerIconPosition(option));
     // Emit a signal when the icon is clicked
@@ -109,7 +110,7 @@ bool ObjectTreeRowButtons::editorEvent(QEvent *event, QAbstractItemModel *model,
         QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>(event);
         if (visibilityIconRect.contains(mouseEvent->pos())) {
             emit visibilityButtonClicked(objectId);
-            visibilityState = objectTree->getItems()[objectId]->getVisibilityState();
+            visibilityState = objTreeItem->getVisibilityState();
             return true;
         }
         else if (centerIconRect.contains(mouseEvent->pos())) {

--- a/src/gui/ObjectTreeRowButtons.cpp
+++ b/src/gui/ObjectTreeRowButtons.cpp
@@ -78,13 +78,13 @@ void ObjectTreeRowButtons::paint(QPainter *painter, const QStyleOptionViewItem &
     QStyledItemDelegate::paint(painter, option, index);
     if (option.state & QStyle::State_MouseOver) {
         switch (visibilityState){
-            case ObjectTree::Invisible:
+            case ObjectTreeItem::Invisible:
                 painter->drawImage(visibilityIconPosition(option), iconInvisible);
                 break;
-            case ObjectTree::SomeChildrenVisible:
+            case ObjectTreeItem::SomeChildrenVisible:
                 painter->drawImage(visibilityIconPosition(option), iconSomeChildrenVisible);
                 break;
-            case ObjectTree::FullyVisible:
+            case ObjectTreeItem::FullyVisible:
                 painter->drawImage(visibilityIconPosition(option), iconFullVisible);
                 break;
         }

--- a/src/gui/ObjectTreeRowButtons.cpp
+++ b/src/gui/ObjectTreeRowButtons.cpp
@@ -101,7 +101,7 @@ QSize ObjectTreeRowButtons::sizeHint(const QStyleOptionViewItem &option, const Q
 
 bool ObjectTreeRowButtons::editorEvent(QEvent *event, QAbstractItemModel *model, const QStyleOptionViewItem &option, const QModelIndex &index) {
     objectId = index.data(Qt::UserRole).toInt();
-    visibilityState = objectTree->getObjectVisibility()[objectId];
+    visibilityState = objectTree->getItems()[objectId]->getVisibilityState();
     QRect visibilityIconRect = iconFullVisible.rect().translated(visibilityIconPosition(option));
     QRect centerIconRect = iconFullVisible.rect().translated(centerIconPosition(option));
     // Emit a signal when the icon is clicked
@@ -109,7 +109,7 @@ bool ObjectTreeRowButtons::editorEvent(QEvent *event, QAbstractItemModel *model,
         QMouseEvent *mouseEvent = dynamic_cast<QMouseEvent *>(event);
         if (visibilityIconRect.contains(mouseEvent->pos())) {
             emit visibilityButtonClicked(objectId);
-            visibilityState = objectTree->getObjectVisibility()[objectId];
+            visibilityState = objectTree->getItems()[objectId]->getVisibilityState();
             return true;
         }
         else if (centerIconRect.contains(mouseEvent->pos())) {

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -122,16 +122,16 @@ const QHash<size_t, QTreeWidgetItem *> &ObjectTreeWidget::getObjectIdTreeWidgetI
 }
 
 void ObjectTreeWidget::refreshItemTextColors() {
-    document->getObjectTree()->traverseSubTree(0, false, [this](size_t objectId) {
-        switch (document->getObjectTree()->getItems()[objectId]->getVisibilityState()) {
+    document->getObjectTree()->traverseSubTree(document->getObjectTree()->getRootItem(), false, [this](ObjectTreeItem* currItem) {
+        switch (currItem->getVisibilityState()) {
             case ObjectTreeItem::Invisible:
-                objectIdTreeWidgetItemMap[objectId]->setForeground(0, QBrush(colorInvisible));
+                objectIdTreeWidgetItemMap[currItem->getObjectId()]->setForeground(0, QBrush(colorInvisible));
                 break;
             case ObjectTreeItem::SomeChildrenVisible:
-                objectIdTreeWidgetItemMap[objectId]->setForeground(0, QBrush(colorSomeChildrenVisible));
+                objectIdTreeWidgetItemMap[currItem->getObjectId()]->setForeground(0, QBrush(colorSomeChildrenVisible));
                 break;
             case ObjectTreeItem::FullyVisible:
-                objectIdTreeWidgetItemMap[objectId]->setForeground(0, QBrush(colorFullVisible));
+                objectIdTreeWidgetItemMap[currItem->getObjectId()]->setForeground(0, QBrush(colorFullVisible));
                 break;
         }
 

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -83,7 +83,7 @@ void ObjectTreeWidget::build(const size_t objectId, QTreeWidgetItem* parent) {
         item = new QTreeWidgetItem();
         objectIdTreeWidgetItemMap[objectId] = item;
         item->setText(0, objTreeItem->getName());
-        item->setData(0, Qt::UserRole, (unsigned int)objectId);
+        item->setData(0, Qt::UserRole, (quint64)objectId);
 
         if (parent != nullptr)
             parent->addChild(item);

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -51,7 +51,7 @@ ObjectTreeWidget::ObjectTreeWidget(Document* document, QWidget* parent) : docume
         // Qt changes foreground color for selected items. We don't want it changed
         setStyleSheet("ObjectTreeWidget::item:selected { color: "+current->foreground(0).color().name()+";}");
     });
-    connect(visibilityButton, &ObjectTreeRowButtons::visibilityButtonClicked, this, [this](unsigned int objectId){
+    connect(visibilityButton, &ObjectTreeRowButtons::visibilityButtonClicked, this, [this](size_t objectId){
         switch(this->document->getObjectTree()->getItems()[objectId]->getVisibilityState()){
             case ObjectTreeItem::Invisible:
             case ObjectTreeItem::SomeChildrenVisible:
@@ -66,7 +66,7 @@ ObjectTreeWidget::ObjectTreeWidget(Document* document, QWidget* parent) : docume
         refreshItemTextColors();
     });
 
-    connect(visibilityButton, &ObjectTreeRowButtons::centerButtonClicked, this, [this](unsigned int objectId){
+    connect(visibilityButton, &ObjectTreeRowButtons::centerButtonClicked, this, [this](size_t objectId){
         this->document->getViewport()->getCamera()->centerView(objectId);
         this->document->getViewportGrid()->forceRerenderAllViewports();
         refreshItemTextColors();
@@ -74,7 +74,7 @@ ObjectTreeWidget::ObjectTreeWidget(Document* document, QWidget* parent) : docume
     refreshItemTextColors();
 }
 
-void ObjectTreeWidget::build(const unsigned int objectId, QTreeWidgetItem* parent) {
+void ObjectTreeWidget::build(const size_t objectId, QTreeWidgetItem* parent) {
     ObjectTreeItem *objTreeItem = document->getObjectTree()->getItems()[objectId];
 
 	QTreeWidgetItem* item;
@@ -83,7 +83,7 @@ void ObjectTreeWidget::build(const unsigned int objectId, QTreeWidgetItem* paren
         item = new QTreeWidgetItem();
         objectIdTreeWidgetItemMap[objectId] = item;
         item->setText(0, objTreeItem->getName());
-        item->setData(0, Qt::UserRole, objectId);
+        item->setData(0, Qt::UserRole, (unsigned int)objectId);
 
         if (parent != nullptr)
             parent->addChild(item);
@@ -102,7 +102,7 @@ void ObjectTreeWidget::select(QString selected) {
     int regionNameIndex = 1;
     int mapSize = document->getObjectTree()->getItems().size();
 
-    for (unsigned int objectId = 1; objectId < mapSize; ++objectId) {
+    for (size_t objectId = 1; objectId < mapSize; ++objectId) {
         if (document->getObjectTree()->getItems()[objectId]->getPath() == path) {
             if (regionNameIndex == regionNameSize - 1) {
                 objectIdTreeWidgetItemMap[objectId]->setSelected(true);
@@ -117,12 +117,12 @@ void ObjectTreeWidget::select(QString selected) {
 }
 
 
-const QHash<unsigned int, QTreeWidgetItem *> &ObjectTreeWidget::getObjectIdTreeWidgetItemMap() const {
+const QHash<size_t, QTreeWidgetItem *> &ObjectTreeWidget::getObjectIdTreeWidgetItemMap() const {
     return objectIdTreeWidgetItemMap;
 }
 
 void ObjectTreeWidget::refreshItemTextColors() {
-    document->getObjectTree()->traverseSubTree(0, false, [this](unsigned int objectId) {
+    document->getObjectTree()->traverseSubTree(0, false, [this](size_t objectId) {
         switch (document->getObjectTree()->getItems()[objectId]->getVisibilityState()) {
             case ObjectTreeItem::Invisible:
                 objectIdTreeWidgetItemMap[objectId]->setForeground(0, QBrush(colorInvisible));

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -83,7 +83,7 @@ void ObjectTreeWidget::build(const size_t objectId, QTreeWidgetItem* parent) {
         item = new QTreeWidgetItem();
         objectIdTreeWidgetItemMap[objectId] = item;
         item->setText(0, objTreeItem->getName());
-        item->setData(0, Qt::UserRole, (quint64)objectId);
+        item->setData(0, Qt::UserRole, (qulonglong)objectId);
 
         if (parent != nullptr)
             parent->addChild(item);

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -53,12 +53,12 @@ ObjectTreeWidget::ObjectTreeWidget(Document* document, QWidget* parent) : docume
     });
     connect(visibilityButton, &ObjectTreeRowButtons::visibilityButtonClicked, this, [this](unsigned int objectId){
         switch(this->document->getObjectTree()->getItems()[objectId]->getVisibilityState()){
-            case ObjectTree::Invisible:
-            case ObjectTree::SomeChildrenVisible:
-                this->document->getObjectTree()->nChangeVisibilityState(objectId, true);
+            case ObjectTreeItem::Invisible:
+            case ObjectTreeItem::SomeChildrenVisible:
+                this->document->getObjectTree()->changeVisibilityState(objectId, true);
                 break;
-            case ObjectTree::FullyVisible:
-                this->document->getObjectTree()->nChangeVisibilityState(objectId, false);
+            case ObjectTreeItem::FullyVisible:
+                this->document->getObjectTree()->changeVisibilityState(objectId, false);
                 break;
         }
         this->document->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
@@ -91,9 +91,8 @@ void ObjectTreeWidget::build(const unsigned int objectId, QTreeWidgetItem* paren
             addTopLevelItem(item);
     }
 
-	for (ObjectTreeItem *objTreeItemChild : objTreeItem->getChildren()) {
+	for (ObjectTreeItem *objTreeItemChild : objTreeItem->getChildren())
 		build(objTreeItemChild->getObjectId(), (objectId != 0) ? item: nullptr);
-	}
 }
 
 void ObjectTreeWidget::select(QString selected) {
@@ -101,10 +100,10 @@ void ObjectTreeWidget::select(QString selected) {
     QString path = "/" + regionName[1];
     int regionNameSize = regionName.size();
     int regionNameIndex = 1;
-    int mapSize = document->getObjectTree()->getFullPathMap().size();
+    int mapSize = document->getObjectTree()->getItems().size();
 
     for (unsigned int objectId = 1; objectId < mapSize; ++objectId) {
-        if (document->getObjectTree()->getFullPathMap()[objectId] == path) {
+        if (document->getObjectTree()->getItems()[objectId]->getPath() == path) {
             if (regionNameIndex == regionNameSize - 1) {
                 objectIdTreeWidgetItemMap[objectId]->setSelected(true);
                 document->getProperties()->bindObject(objectId);
@@ -123,15 +122,15 @@ const QHash<unsigned int, QTreeWidgetItem *> &ObjectTreeWidget::getObjectIdTreeW
 }
 
 void ObjectTreeWidget::refreshItemTextColors() {
-    document->getObjectTree()->nTraverseSubTree(0, false, [this](unsigned int objectId) {
+    document->getObjectTree()->traverseSubTree(0, false, [this](unsigned int objectId) {
         switch (document->getObjectTree()->getItems()[objectId]->getVisibilityState()) {
-            case ObjectTree::Invisible:
+            case ObjectTreeItem::Invisible:
                 objectIdTreeWidgetItemMap[objectId]->setForeground(0, QBrush(colorInvisible));
                 break;
-            case ObjectTree::SomeChildrenVisible:
+            case ObjectTreeItem::SomeChildrenVisible:
                 objectIdTreeWidgetItemMap[objectId]->setForeground(0, QBrush(colorSomeChildrenVisible));
                 break;
-            case ObjectTree::FullyVisible:
+            case ObjectTreeItem::FullyVisible:
                 objectIdTreeWidgetItemMap[objectId]->setForeground(0, QBrush(colorFullVisible));
                 break;
         }

--- a/src/gui/Properties.cpp
+++ b/src/gui/Properties.cpp
@@ -23,7 +23,7 @@ Properties::Properties(Document & document) : document(document), object(nullptr
 }
 
 
-void Properties::bindObject(const unsigned int objectId) {
+void Properties::bindObject(const size_t objectId) {
     this->fullPath = document.getObjectTree()->getItems()[objectId]->getPath();
     this->name = fullPath.split("/").last();
     fullPathWidget->setText(QString(fullPath).replace("/"," / "));

--- a/src/gui/Properties.cpp
+++ b/src/gui/Properties.cpp
@@ -23,8 +23,8 @@ Properties::Properties(Document & document) : document(document), object(nullptr
 }
 
 
-void Properties::bindObject(const int objectId) {
-    this->fullPath = document.getObjectTree()->getFullPathMap()[objectId];
+void Properties::bindObject(const unsigned int objectId) {
+    this->fullPath = document.getObjectTree()->getItems()[objectId]->getPath();
     this->name = fullPath.split("/").last();
     fullPathWidget->setText(QString(fullPath).replace("/"," / "));
 

--- a/src/gui/TypeSpecificProperties.cpp
+++ b/src/gui/TypeSpecificProperties.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 
 
-TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Object *object, const int objectId)
+TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Object *object, const unsigned int objectId)
         : document(document), object(object) {
     setObjectName("properties-TypeSpecificProperties");
     l = getBoxLayout();
@@ -46,9 +46,8 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
         childrenListCollapsible->setTitle("Children");
         childrenListCollapsible->setWidget(childrenList);
 
-        for (int childId : document.getObjectTree()->getChildren()[objectId]){
-            QString childName = document.getObjectTree()->getNameMap()[childId];
-            childrenList->addWidget(new QLabel(childName));
+        for (ObjectTreeItem *child : document.getObjectTree()->getItems()[objectId]->getChildren()){
+            childrenList->addWidget(new QLabel(child->getName()));
         }
 
         QCheckBox *hasColorCheck = new QCheckBox();
@@ -58,7 +57,7 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
         hasColorCheck->setText("Has Color");
         hasColorCheck->setCheckState(comb->HasColor() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
         connect(hasColorCheck,&QCheckBox::stateChanged,[this,objectId](int newState){
-            this->document.getBRLCADObject(this->document.getObjectTree()->getFullPathMap()[objectId],[newState](BRLCAD::Object &object){
+            this->document.getBRLCADObject(this->document.getObjectTree()->getItems()[objectId]->getPath(),[newState](BRLCAD::Object &object){
                 if(newState == Qt::CheckState::Checked){
                     dynamic_cast<BRLCAD::Combination&>(object).SetHasColor(true);
                 }
@@ -72,7 +71,7 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
 
         QPushButton *colorButton = new QPushButton();
         colorButton->setObjectName("colorButton");
-        colorButton->setStyleSheet("background-color:"+document.getObjectTree()->getColorMap()[objectId].toHexString());
+        colorButton->setStyleSheet("background-color:"+document.getObjectTree()->getItems()[objectId]->getColorInfo().toHexString());
         colorHolder->addWidget(colorButton);
         /*connect(colorButton, &QPushButton::clicked, this, [this,objectId](){
             const QColor &initial = this->document.getObjectTree()->getColorMap()[objectId].toQColor();

--- a/src/gui/TypeSpecificProperties.cpp
+++ b/src/gui/TypeSpecificProperties.cpp
@@ -46,7 +46,8 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
         childrenListCollapsible->setTitle("Children");
         childrenListCollapsible->setWidget(childrenList);
 
-        for (ObjectTreeItem *child : document.getObjectTree()->getItems()[objectId]->getChildren()){
+        ObjectTreeItem* item = document.getObjectTree()->getItems()[objectId];
+        for (ObjectTreeItem *child : item->getChildren()){
             childrenList->addWidget(new QLabel(child->getName()));
         }
 
@@ -56,8 +57,8 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
         colorHolder->setStyleSheet("margin-top:11px;");
         hasColorCheck->setText("Has Color");
         hasColorCheck->setCheckState(comb->HasColor() ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);
-        connect(hasColorCheck,&QCheckBox::stateChanged,[this,objectId](int newState){
-            this->document.getBRLCADObject(this->document.getObjectTree()->getItems()[objectId]->getPath(),[newState](BRLCAD::Object &object){
+        connect(hasColorCheck,&QCheckBox::stateChanged,[this,item](int newState){
+            this->document.getBRLCADObject(item->getPath(),[newState](BRLCAD::Object &object){
                 if(newState == Qt::CheckState::Checked){
                     dynamic_cast<BRLCAD::Combination&>(object).SetHasColor(true);
                 }
@@ -71,7 +72,7 @@ TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Objec
 
         QPushButton *colorButton = new QPushButton();
         colorButton->setObjectName("colorButton");
-        colorButton->setStyleSheet("background-color:"+document.getObjectTree()->getItems()[objectId]->getColorInfo().toHexString());
+        colorButton->setStyleSheet("background-color:"+item->getColorInfo().toHexString());
         colorHolder->addWidget(colorButton);
         /*connect(colorButton, &QPushButton::clicked, this, [this,objectId](){
             const QColor &initial = this->document.getObjectTree()->getColorMap()[objectId].toQColor();

--- a/src/gui/TypeSpecificProperties.cpp
+++ b/src/gui/TypeSpecificProperties.cpp
@@ -28,7 +28,7 @@ using namespace std;
 
 
 
-TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Object *object, const unsigned int objectId)
+TypeSpecificProperties::TypeSpecificProperties(Document &document, BRLCAD::Object *object, const size_t objectId)
         : document(document), object(object) {
     setObjectName("properties-TypeSpecificProperties");
     l = getBoxLayout();

--- a/src/viewport/GeometryRenderer.cpp
+++ b/src/viewport/GeometryRenderer.cpp
@@ -30,7 +30,7 @@ GeometryRenderer::GeometryRenderer(Document* document) : document(document)
 void GeometryRenderer::render() {
     document->getViewport()->getViewportManager()->saveState();
     if (!objectsToBeViewportedIds.empty()) {
-        for (unsigned int objectId : objectsToBeViewportedIds) {
+        for (size_t objectId : objectsToBeViewportedIds) {
             if (!objectIdViewportListIdMap.contains(objectId)) {
                 drawSolid(objectId);
             }
@@ -47,7 +47,7 @@ void GeometryRenderer::render() {
 }
 
 
-void GeometryRenderer::drawSolid(unsigned int objectId) {
+void GeometryRenderer::drawSolid(size_t objectId) {
     ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
     const ColorInfo colorInfo = item->getColorInfo();
     const QString objectFullPath = item->getPath();
@@ -56,7 +56,7 @@ void GeometryRenderer::drawSolid(unsigned int objectId) {
 
     clearSolidIfAvailable(objectId);
 
-    const unsigned int displayListId = document->getViewport()->getViewportManager()->genDLists(1);
+    const size_t displayListId = document->getViewport()->getViewportManager()->genDLists(1);
     document->getViewport()->getViewportManager()->beginDList(displayListId);  // begin display list --------------
 
     if (colorInfo.hasColor) {
@@ -77,7 +77,7 @@ void GeometryRenderer::drawSolid(unsigned int objectId) {
 
 void GeometryRenderer::refreshForVisibilityAndSolidChanges() {
     visibleViewportListIds.clear();
-    document->getObjectTree()->traverseSubTree(0, false, [this](unsigned int objectId)
+    document->getObjectTree()->traverseSubTree(0, false, [this](size_t objectId)
         {
             ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
             if (item->getVisibilityState() == ObjectTreeItem::Invisible) return false;
@@ -88,15 +88,15 @@ void GeometryRenderer::refreshForVisibilityAndSolidChanges() {
     );
 }
 
-void GeometryRenderer::clearSolidIfAvailable(unsigned int objectId) {
+void GeometryRenderer::clearSolidIfAvailable(size_t objectId) {
     if (objectIdViewportListIdMap.contains(objectId)){
         document->getViewport()->getViewportManager()->freeDLists(objectIdViewportListIdMap[objectId], 1);
         objectIdViewportListIdMap.remove(objectId);
     }
 }
 
-void GeometryRenderer::clearObject(unsigned int objectId) {
-    document->getObjectTree()->traverseSubTree(objectId, true, [this](unsigned int objectId){
+void GeometryRenderer::clearObject(size_t objectId) {
+    document->getObjectTree()->traverseSubTree(objectId, true, [this](size_t objectId){
         clearSolidIfAvailable(objectId);
         return true;
     });

--- a/src/viewport/GeometryRenderer.cpp
+++ b/src/viewport/GeometryRenderer.cpp
@@ -31,17 +31,16 @@ void GeometryRenderer::render() {
     document->getViewport()->getViewportManager()->saveState();
     if (!objectsToBeViewportedIds.empty()) {
         for (size_t objectId : objectsToBeViewportedIds) {
-            if (!objectIdViewportListIdMap.contains(objectId)) {
+            if (!objectIdViewportListIdMap.contains(objectId))
                 drawSolid(objectId);
-            }
             visibleViewportListIds.append(objectIdViewportListIdMap[objectId]);
         }
         objectsToBeViewportedIds.clear();
     }
 
-    for (int displayListId : visibleViewportListIds) {
+    for (size_t displayListId : visibleViewportListIds)
         document->getViewport()->getViewportManager()->drawDList(displayListId);
-    }
+
     document->getViewport()->getViewportManager()->drawSuffix();
     document->getViewport()->getViewportManager()->restoreState();
 }

--- a/src/viewport/GeometryRenderer.cpp
+++ b/src/viewport/GeometryRenderer.cpp
@@ -76,12 +76,10 @@ void GeometryRenderer::drawSolid(size_t objectId) {
 
 void GeometryRenderer::refreshForVisibilityAndSolidChanges() {
     visibleViewportListIds.clear();
-    document->getObjectTree()->traverseSubTree(0, false, [this](size_t objectId)
-        {
-            ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
-            if (item->getVisibilityState() == ObjectTreeItem::Invisible) return false;
-            if (!item->isDrawable()) return true;
-            objectsToBeViewportedIds.append(objectId);
+    document->getObjectTree()->traverseSubTree(document->getObjectTree()->getRootItem(), false, [this](ObjectTreeItem* currItem) {
+            if (currItem->getVisibilityState() == ObjectTreeItem::Invisible) return false;
+            if (!currItem->isDrawable()) return true;
+            objectsToBeViewportedIds.append(currItem->getObjectId());
             return true;
         }
     );
@@ -95,8 +93,8 @@ void GeometryRenderer::clearSolidIfAvailable(size_t objectId) {
 }
 
 void GeometryRenderer::clearObject(size_t objectId) {
-    document->getObjectTree()->traverseSubTree(objectId, true, [this](size_t objectId){
-        clearSolidIfAvailable(objectId);
+    document->getObjectTree()->traverseSubTree(document->getObjectTree()->getRootItem(), true, [this](ObjectTreeItem* currItem){
+        clearSolidIfAvailable(currItem->getObjectId());
         return true;
     });
 }

--- a/src/viewport/OrthographicCamera.cpp
+++ b/src/viewport/OrthographicCamera.cpp
@@ -151,16 +151,14 @@ void OrthographicCamera::centerToCurrentSelection() {
 
 void OrthographicCamera::autoview() {
     document->getDatabase()->UnSelectAll();
-    document->getObjectTree()->traverseSubTree(0, false, [this]
-    (size_t objectId){
-        ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
-        switch(item->getVisibilityState()){
+    document->getObjectTree()->traverseSubTree(document->getObjectTree()->getRootItem(), false, [this](ObjectTreeItem* currItem){
+        switch(currItem->getVisibilityState()){
             case ObjectTreeItem::Invisible:
                 return false;
             case ObjectTreeItem::SomeChildrenVisible:
                 return true;
             case ObjectTreeItem::FullyVisible:
-                document->getDatabase()->Select(item->getPath().toUtf8());
+                document->getDatabase()->Select(currItem->getPath().toUtf8());
                 return false;
         }
         return true;

--- a/src/viewport/OrthographicCamera.cpp
+++ b/src/viewport/OrthographicCamera.cpp
@@ -152,7 +152,7 @@ void OrthographicCamera::centerToCurrentSelection() {
 void OrthographicCamera::autoview() {
     document->getDatabase()->UnSelectAll();
     document->getObjectTree()->traverseSubTree(0, false, [this]
-    (unsigned int objectId){
+    (size_t objectId){
         ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
         switch(item->getVisibilityState()){
             case ObjectTreeItem::Invisible:
@@ -170,7 +170,7 @@ void OrthographicCamera::autoview() {
     centerToCurrentSelection();
 }
 
-void OrthographicCamera::centerView(unsigned int objectId) {
+void OrthographicCamera::centerView(size_t objectId) {
     document->getDatabase()->UnSelectAll();
     QString fullPath = document->getObjectTree()->getItems()[objectId]->getPath();
     document->getDatabase()->Select(fullPath.toUtf8());

--- a/src/viewport/OrthographicCamera.cpp
+++ b/src/viewport/OrthographicCamera.cpp
@@ -22,7 +22,7 @@
 #include "OrthographicCamera.h"
 #include "Utils.h"
 #include <cmath>
-#include <QDebug>
+
 
 QMatrix4x4 OrthographicCamera::modelViewMatrix() const {
     QMatrix4x4 rotationMatrixAroundX;
@@ -152,15 +152,15 @@ void OrthographicCamera::centerToCurrentSelection() {
 void OrthographicCamera::autoview() {
     document->getDatabase()->UnSelectAll();
     document->getObjectTree()->traverseSubTree(0, false, [this]
-    (int objectId){
-        switch(document->getObjectTree()->getObjectVisibility()[objectId]){
-            case ObjectTree::Invisible:
+    (unsigned int objectId){
+        ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
+        switch(item->getVisibilityState()){
+            case ObjectTreeItem::Invisible:
                 return false;
-            case ObjectTree::SomeChildrenVisible:
+            case ObjectTreeItem::SomeChildrenVisible:
                 return true;
-            case ObjectTree::FullyVisible:
-                QString fullPath = document->getObjectTree()->getFullPathMap()[objectId];
-                document->getDatabase()->Select(fullPath.toUtf8());
+            case ObjectTreeItem::FullyVisible:
+                document->getDatabase()->Select(item->getPath().toUtf8());
                 return false;
         }
         return true;
@@ -170,9 +170,9 @@ void OrthographicCamera::autoview() {
     centerToCurrentSelection();
 }
 
-void OrthographicCamera::centerView(int objectId) {
+void OrthographicCamera::centerView(unsigned int objectId) {
     document->getDatabase()->UnSelectAll();
-    QString fullPath = document->getObjectTree()->getFullPathMap()[objectId];
+    QString fullPath = document->getObjectTree()->getItems()[objectId]->getPath();
     document->getDatabase()->Select(fullPath.toUtf8());
     centerToCurrentSelection();
 }

--- a/src/viewport/RaytraceView.cpp
+++ b/src/viewport/RaytraceView.cpp
@@ -158,14 +158,15 @@ void RaytraceView::raytrace() {
     hide();
     document->getDatabase()->UnSelectAll();
     document->getObjectTree()->traverseSubTree(0, false, [this]
-                                                       (int objectId){
-                                                   switch(document->getObjectTree()->getObjectVisibility()[objectId]){
-                                                       case ObjectTree::Invisible:
+                                                       (unsigned int objectId){
+                                                   ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
+                                                   switch(item->getVisibilityState()){
+                                                       case ObjectTreeItem::Invisible:
                                                            return false;
-                                                       case ObjectTree::SomeChildrenVisible:
+                                                       case ObjectTreeItem::SomeChildrenVisible:
                                                            return true;
-                                                       case ObjectTree::FullyVisible:
-                                                           QString fullPath = document->getObjectTree()->getFullPathMap()[objectId];
+                                                       case ObjectTreeItem::FullyVisible:
+                                                           QString fullPath = item->getPath();
                                                            document->getDatabase()->Select(fullPath.toUtf8());
                                                            return false;
                                                    }

--- a/src/viewport/RaytraceView.cpp
+++ b/src/viewport/RaytraceView.cpp
@@ -158,7 +158,7 @@ void RaytraceView::raytrace() {
     hide();
     document->getDatabase()->UnSelectAll();
     document->getObjectTree()->traverseSubTree(0, false, [this]
-                                                       (unsigned int objectId){
+                                                       (size_t objectId){
                                                    ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
                                                    switch(item->getVisibilityState()){
                                                        case ObjectTreeItem::Invisible:

--- a/src/viewport/RaytraceView.cpp
+++ b/src/viewport/RaytraceView.cpp
@@ -157,22 +157,19 @@ void RaytraceView::raytrace() {
 
     hide();
     document->getDatabase()->UnSelectAll();
-    document->getObjectTree()->traverseSubTree(0, false, [this]
-                                                       (size_t objectId){
-                                                   ObjectTreeItem *item = document->getObjectTree()->getItems()[objectId];
-                                                   switch(item->getVisibilityState()){
-                                                       case ObjectTreeItem::Invisible:
-                                                           return false;
-                                                       case ObjectTreeItem::SomeChildrenVisible:
-                                                           return true;
-                                                       case ObjectTreeItem::FullyVisible:
-                                                           QString fullPath = item->getPath();
-                                                           document->getDatabase()->Select(fullPath.toUtf8());
-                                                           return false;
-                                                   }
-                                                   return true;
-                                               }
-    );
+    document->getObjectTree()->traverseSubTree(document->getObjectTree()->getRootItem(), false, [this](ObjectTreeItem* currItem) {
+        switch(currItem->getVisibilityState()){
+            case ObjectTreeItem::Invisible:
+                return false;
+            case ObjectTreeItem::SomeChildrenVisible:
+                return true;
+            case ObjectTreeItem::FullyVisible:
+                QString fullPath = currItem->getPath();
+                document->getDatabase()->Select(fullPath.toUtf8());
+                return false;
+        }
+        return true;
+    });
 
     QMatrix4x4 transformation;
     transformation.translate(document->getViewport()->getCamera()->getEyePosition().x(),

--- a/src/viewport/ViewportManager.cpp
+++ b/src/viewport/ViewportManager.cpp
@@ -348,14 +348,14 @@ void ViewportManager::setLineAttr(int width, int style)
 /*
  * Viewports a saved display list identified by `list`
  */
-void ViewportManager::drawDList(unsigned int list) {
-    glCallList((GLuint) list);
+void ViewportManager::drawDList(size_t list) {
+    glCallList((GLsizei) list);
 }
 
 /*
  * Generates `range` number of display lists and returns first display list's index
  */
-unsigned int ViewportManager::genDLists(size_t range)
+size_t ViewportManager::genDLists(size_t range)
 {
     return glGenLists((GLsizei)range);
 }
@@ -364,9 +364,9 @@ unsigned int ViewportManager::genDLists(size_t range)
  * Supported subsequent opengl commands are compiled into the display list `list` rather than being rendered to the screen.
  * Should have called genDLists and generated the display list before calling this.
  */
-void ViewportManager::beginDList(unsigned int list)
+void ViewportManager::beginDList(size_t list)
 {
-    glNewList((GLuint)list, GL_COMPILE);
+    glNewList((GLsizei)list, GL_COMPILE);
 }
 
 /*
@@ -380,14 +380,14 @@ void ViewportManager::endDList()
 /*
  * End of the display list initiated by beginDList.
  */
-GLboolean ViewportManager::isDListValid(unsigned int list)
+GLboolean ViewportManager::isDListValid(size_t list)
 {
     return glIsList(list);
 }
 
-void ViewportManager::freeDLists(unsigned int list, int range)
+void ViewportManager::freeDLists(size_t list, size_t range)
 {
-    glDeleteLists((GLuint)list, (GLsizei)range);
+    glDeleteLists((GLsizei)list, (GLsizei)range);
 }
 void ViewportManager::drawBegin()
 {


### PR DESCRIPTION
~~**THIS PR IS A WORK IN PROGRESS, AND SHOULD NOT BE MERGED**~~

---

The goal of this PR is to replace the current `ObjectTree`, which works using many `QHash` that connect an unique object id to a specific object data, with a new `ObjectTree` that uses only 2 `QHash`.

The first `QHash` connects a unique object id to a `ObjectTreeItem` object, that contains all the informations that describe an object item inside the database tree (eg: parent [`ObjectTreeItem*`], children [`QVector<ObjectTreeItem*>`], visibilityState [`enum`], ...).

This is done to handle situations where the same object can appear more than once in a database. For example, if we have a database tree where there are many occurrences of the object "obj":
```
 comb1.c
    |_____ u obj
    |         |_____ u sph1.s
    |         |_____ - sph2.s
   ...
 comb2.c
    |_____ u obj
              |_____ u sph1.s
              |_____ - sph2.s
```
it's easy to see that if we want to draw "comb1.c", we want to draw the instance of "obj" that is a child of "comb1.c", and the instances of "sph1.s" and "sph2.s" that are children of the instance of "obj" that we described before. Only these objects need to be a visibilityState of "FullyVisible".

It's also easy to see though that "obj", and its children "sph1.s" and "sph2.s", are the same object. And this means that they share the same data. Which means that, if we execute the GED command "kill sph1.s", all instances of "sph1.s" in the tree will get killed.

To handle these situations, were we need to change data across all instances of an `ObjectTreeItem`, we make it so that every `ObjectTreeItem` has a reference to an `ObjectTreeItemData` object, that contains all the informations that describe a unique object in the database (eg: isAlive [`bool`], isDrawable [`bool`], color [`ColorInfo`], ...).

This means that there will always be a 1:1 ratio between database objects and `ObjectTreeItemData` objects, but there will be a 1:1 ratio between database objects and `ObjectTreeItem` only if all objects appear only once in the database tree.

The second `QHash`, infact, connects a database object name to its correspondent `ObjectTreeItemData`.