### PR TITLE
Fix segmentation fault when an object is selected in `ObjectTreeWidget`

### DIFF
--- a/include/Document.h
+++ b/include/Document.h
@@ -1,6 +1,28 @@
-//
-// Created by Sadeep on 11-Jun.
-//
+/*                          D O C U M E N T . H
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file Document.h */
 
 #ifndef RT3_DOCUMENT_H
 #define RT3_DOCUMENT_H
@@ -13,6 +35,7 @@
 #include "ViewportGrid.h"
 #include <include/RaytraceView.h>
 
+
 class Properties;
 class Viewport;
 class GeometryRenderer;
@@ -20,6 +43,7 @@ class ViewportGrid;
 class RaytraceView;
 class ObjectTreeWidget;
 class Console;
+
 
 class Document {
 private:

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -1,7 +1,7 @@
 /*                          O B J E C T T R E E . H
  * BRL-CAD
  *
- * Copyright (c) 2018-2025 United States Government as represented by
+ * Copyright (c) 2020-2025 United States Government as represented by
  * the U.S. Army Research Laboratory.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -215,7 +215,7 @@ private:
 class ObjectTree : public QObject {
     Q_OBJECT
 public:
-    ObjectTree(BRLCAD::MemoryDatabase* database);
+    ObjectTree(BRLCAD::MemoryDatabase* database, Document* document);
     ~ObjectTree();
 
     size_t lastAllocatedId = 0;
@@ -266,6 +266,7 @@ public:
 	
 private:
     BRLCAD::MemoryDatabase* database;
+    Document* document;
 
     class BuildObjectTreeClbk {
     public:

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -23,6 +23,7 @@
  * SOFTWARE.
  */
 /** @file ObjectTree.h
+ * 
  *  Generates and stores the object tree of a database.
  *
  *  The ObjectTree is composed of:

--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -235,6 +235,8 @@ public:
 
     static void databaseChangeHandler(const char* objectName, BRLCAD::ConstDatabase::ChangeType changeType);
 
+    void buildColorMap(size_t rootObjectId);
+
     void cmdExecutionStarted();
     void cmdExecutionEnded();
 

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -1,7 +1,7 @@
 /*                     O B J E C T T R E E W I D G E T . H
  * BRL-CAD
  *
- * Copyright (c) 2018-2025 United States Government as represented by
+ * Copyright (c) 2020-2025 United States Government as represented by
  * the U.S. Army Research Laboratory.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -1,7 +1,7 @@
-/*                      O B J E C T S T R E E V I E W . H
+/*                     O B J E C T T R E E W I D G E T . H
  * BRL-CAD
  *
- * Copyright (c) 2018 United States Government as represented by
+ * Copyright (c) 2018-2025 United States Government as represented by
  * the U.S. Army Research Laboratory.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -22,32 +22,35 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-/** @file ObjectTreeWidget.h
- *
- */
+/** @file ObjectTreeWidget.h */
 
 #ifndef OBJECTTREEWIDGET_H
 #define OBJECTTREEWIDGET_H
 
-#include <QTreeView>
-#include <qtreewidget.h>
-#include <QtWidgets/QStyledItemDelegate>
-#include "ObjectTree.h"
-#include <QApplication>
-#include <QMouseEvent>
-#include <QPainter>
+#include <QTreeWidget>
+
+
 class Document;
+
+
 class ObjectTreeWidget : public QTreeWidget {
     Q_OBJECT
 public:
-    explicit ObjectTreeWidget(Document *objectTree,   QWidget *parent = nullptr);
-    void refreshItemTextColors();
-    const QHash<size_t, QTreeWidgetItem *> &getObjectIdTreeWidgetItemMap() const;
+    explicit ObjectTreeWidget(Document *document, QWidget *parent = nullptr);
+
     void build(const size_t objectId, QTreeWidgetItem* parent = nullptr);
     void select(QString selected);
+    void refreshItemTextColors();
     void setTextColor();
+
+    // Getters
+    const QHash<size_t, QTreeWidgetItem *>& getObjectIdTreeWidgetItemMap() const {
+        return objectIdTreeWidgetItemMap;
+    }
+
 private:
     Document* document;
+
     QHash <size_t, QTreeWidgetItem*> objectIdTreeWidgetItemMap;
 
     QColor colorFullVisible;
@@ -58,8 +61,6 @@ private:
 signals:
     void visibilityButtonClicked(size_t objectId);
     void selectionChanged(size_t objectId);
-
-
 };
 
 

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -40,6 +40,7 @@ public:
 
     void build(const size_t objectId, QTreeWidgetItem* parent = nullptr);
     void select(QString selected);
+    void traverseSubTree(QTreeWidgetItem *rootOfSubTree, bool traverseRoot, const std::function<bool(QTreeWidgetItem*)>& callback);
     void refreshItemTextColors();
     void setTextColor();
 

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -39,6 +39,7 @@ public:
     explicit ObjectTreeWidget(Document *document, QWidget *parent = nullptr);
 
     void build(const size_t objectId, QTreeWidgetItem* parent = nullptr);
+    void destroy(const size_t objectId);
     void select(QString selected);
     void traverseSubTree(QTreeWidgetItem *rootOfSubTree, bool traverseRoot, const std::function<bool(QTreeWidgetItem*)>& callback);
     void refreshItemTextColors();

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -51,7 +51,7 @@ public:
 private:
     Document* document;
 
-    QHash <size_t, QTreeWidgetItem*> objectIdTreeWidgetItemMap;
+    QHash<size_t, QTreeWidgetItem*> objectIdTreeWidgetItemMap;
 
     QColor colorFullVisible;
     QColor colorSomeChildrenVisible;

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -36,7 +36,7 @@ class Document;
 class ObjectTreeWidget : public QTreeWidget {
     Q_OBJECT
 public:
-    explicit ObjectTreeWidget(Document *document, QWidget *parent = nullptr);
+    explicit ObjectTreeWidget(Document* document, QWidget* parent = nullptr);
 
     void build(const size_t objectId, QTreeWidgetItem* parent = nullptr);
     void destroy(const size_t objectId);
@@ -47,7 +47,7 @@ public:
     void setTextColor();
 
     // Getters
-    const QHash<size_t, QTreeWidgetItem *>& getObjectIdTreeWidgetItemMap() const {
+    const QHash<size_t, QTreeWidgetItem*>& getObjectIdTreeWidgetItemMap() const {
         return objectIdTreeWidgetItemMap;
     }
 

--- a/include/ObjectTreeWidget.h
+++ b/include/ObjectTreeWidget.h
@@ -40,6 +40,7 @@ public:
 
     void build(const size_t objectId, QTreeWidgetItem* parent = nullptr);
     void destroy(const size_t objectId);
+    void update();
     void select(QString selected);
     void traverseSubTree(QTreeWidgetItem *rootOfSubTree, bool traverseRoot, const std::function<bool(QTreeWidgetItem*)>& callback);
     void refreshItemTextColors();

--- a/include/Properties.h
+++ b/include/Properties.h
@@ -1,22 +1,46 @@
+/*                           P R O P E R T I E S . H
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file Properties.h */
 
 #ifndef RT3_PROPERTIES_H
 #define RT3_PROPERTIES_H
 
 
-#include <QtWidgets/QVBoxLayout>
-#include <QtWidgets/QLabel>
-#include <include/CollapsibleWidget.h>
-#include <brlcad/Database/Database.h>
-#include <brlcad/Database/MemoryDatabase.h>
-#include "Document.h"
+#include <QLabel>
+#include <brlcad/Database/Object.h>
 #include "QVBoxWidget.h"
-#include "TypeSpecificProperties.h"
+
 
 class Document;
 class TypeSpecificProperties;
-class Properties: public QVBoxWidget{
+
+
+class Properties: public QVBoxWidget {
 public:
-    explicit Properties(Document & document);
+    explicit Properties(Document* document);
+
     void bindObject(const size_t objectId);
     void rewriteObjectNameAndType();
 
@@ -24,12 +48,12 @@ private:
     QString name, fullPath, objectType;
 
 	// UI components
-    Document & document;
-    TypeSpecificProperties * current;
-    BRLCAD::Object * object;
-    QLabel * nameWidget;
-    QLabel * fullPathWidget;
-    QVBoxWidget * typeSpecificPropertiesArea;
+    Document* document;
+    TypeSpecificProperties* current;
+    BRLCAD::Object* object;
+    QLabel* nameWidget;
+    QLabel* fullPathWidget;
+    QVBoxWidget* typeSpecificPropertiesArea;
 };
 
 

--- a/include/QHBoxWidget.h
+++ b/include/QHBoxWidget.h
@@ -39,6 +39,7 @@ public:
     QHBoxWidget(QWidget* parent, QWidget *child);
     QHBoxLayout* getBoxLayout();
     void addWidget(QWidget* widget);
+    void removeWidget(QWidget* widget);
 
 private:
     QHBoxLayout* boxLayout;

--- a/include/QHBoxWidget.h
+++ b/include/QHBoxWidget.h
@@ -1,19 +1,47 @@
+/*                      Q H B O X W I D G E T . H
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file QHBoxWidget.h */
 
 #ifndef RT3_QHBOXWIDGET_H
 #define RT3_QHBOXWIDGET_H
 
+#include <QFrame>
+#include <QHBoxLayout>
 
-#include <QtWidgets/QFrame>
-#include <QtWidgets/QHBoxLayout>
 
-class QHBoxWidget : public QFrame{
+class QHBoxWidget : public QFrame {
 public:
     QHBoxWidget(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    ~QHBoxWidget();
+
     QHBoxWidget(QWidget* parent, QWidget *child);
-    QHBoxLayout *getBoxLayout();
+    QHBoxLayout* getBoxLayout();
     void addWidget(QWidget* widget);
+
 private:
-    QHBoxLayout *boxLayout;
+    QHBoxLayout* boxLayout;
 };
 
 

--- a/include/QVBoxWidget.h
+++ b/include/QVBoxWidget.h
@@ -1,4 +1,4 @@
-/*                      Q H B O X W I D G E T . H
+/*                      Q V B O X W I D G E T . H
  * BRL-CAD
  *
  * Copyright (c) 2020-2025 United States Government as represented by

--- a/include/QVBoxWidget.h
+++ b/include/QVBoxWidget.h
@@ -1,19 +1,47 @@
+/*                      Q H B O X W I D G E T . H
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file QHBoxWidget.h */
 
 #ifndef RT3_QVBOXWIDGET_H
 #define RT3_QVBOXWIDGET_H
 
+#include <QFrame>
+#include <QVBoxLayout>
 
-#include <QtWidgets/QFrame>
-#include <QtWidgets/QVBoxLayout>
 
 class QVBoxWidget : public QFrame{
 public:
     QVBoxWidget(QWidget* parent = nullptr, Qt::WindowFlags f = Qt::WindowFlags());
+    ~QVBoxWidget();
+
     QVBoxWidget(QWidget* parent, QWidget* child);
     QVBoxLayout *getBoxLayout();
     void addWidget(QWidget* widget);
+
 private:
-    QVBoxLayout *boxLayout;
+    QVBoxLayout* boxLayout;
 };
 
 

--- a/include/QVBoxWidget.h
+++ b/include/QVBoxWidget.h
@@ -39,6 +39,7 @@ public:
     QVBoxWidget(QWidget* parent, QWidget* child);
     QVBoxLayout *getBoxLayout();
     void addWidget(QWidget* widget);
+    void removeWidget(QWidget* widget);
 
 private:
     QVBoxLayout* boxLayout;

--- a/include/TypeSpecificProperties.h
+++ b/include/TypeSpecificProperties.h
@@ -1,21 +1,48 @@
+/*                T Y P E S P E C I F I C P R O P E R T I E S . H
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file TypeSpecificProperties.h */
 
 #ifndef RT3_TYPESPECIFICPROPERTIES_H
 #define RT3_TYPESPECIFICPROPERTIES_H
 
+#include <QVBoxLayout>
+#include <brlcad/Database/Object.h>
+#include "QVBoxWidget.h"
 
-#include <brlcad/Database/MemoryDatabase.h>
-#include <QtWidgets/QFrame>
-#include <QtWidgets/QVBoxLayout>
-#include "Document.h"
+
+class Document;
+
 
 class TypeSpecificProperties: public QVBoxWidget {
 public:
-    TypeSpecificProperties(Document &document, BRLCAD::Object *object, const size_t objectId);
+    TypeSpecificProperties(Document* document, BRLCAD::Object* object, const size_t objectId);
 
 protected:
-    Document& document;
-    BRLCAD::Object *object;
-    QVBoxLayout *l;
+    Document* document;
+    BRLCAD::Object* object;
+    QVBoxLayout* l;
 };
 
 

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -19,7 +19,7 @@ Document::Document(const int documentId, const QString *filePath) : documentId(d
     }
 
     modified = false;
-    objectTree = new ObjectTree(database);
+    objectTree = new ObjectTree(database, this);
     properties = new Properties(*this);
     console = new Console(this);
     geometryRenderer = new GeometryRenderer(this);

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -1,4 +1,4 @@
-/*                          D O C U M E N T . H
+/*                        D O C U M E N T . C P P
  * BRL-CAD
  *
  * Copyright (c) 2020-2025 United States Government as represented by

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -1,9 +1,32 @@
-//
-// Created by Sadeep on 11-Jun.
-//
+/*                          D O C U M E N T . H
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file Document.h */
+
 
 #include <Document.h>
-#include<Viewport.h>
+#include <Viewport.h>
 #include "Console.h"
 #include <brlcad/Database/Torus.h>
 

--- a/src/Document.cpp
+++ b/src/Document.cpp
@@ -20,7 +20,7 @@ Document::Document(const int documentId, const QString *filePath) : documentId(d
 
     modified = false;
     objectTree = new ObjectTree(database, this);
-    properties = new Properties(*this);
+    properties = new Properties(this);
     console = new Console(this);
     geometryRenderer = new GeometryRenderer(this);
     objectTreeWidget = new ObjectTreeWidget(this);

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -347,7 +347,7 @@ void ObjectTree::updateObjectTree() {
     }
 
     // Temporary solution to rebuild the objectTreeWidget
-    document->getObjectTreeWidget()->build(0);
+    document->getObjectTreeWidget()->update();
     document->getObjectTreeWidget()->refreshItemTextColors();
     document->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
     document->getViewportGrid()->forceRerenderAllViewports();
@@ -559,6 +559,10 @@ void ObjectTree::removeObjectHandler(QString objectName) {
     itemData->setIsAliveFlag(false);
     itemData->setIsDrawableFlag(false);
     itemData->getColorInfo() = {0, 0, 0, false};
+
+    // Make the ObjectTreeItems of the itemData to delete Invisible
+    for (ObjectTreeItem* itemWithThisData : itemData->getItemsWithThisData())
+        changeVisibilityState(itemWithThisData->getObjectId(), false);
 
     // If this is the last queued signal, call updateObjectTree
     if (--queuedSignals == 0)

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -1,7 +1,7 @@
 /*                        O B J E C T T R E E . C P P
  * BRL-CAD
  *
- * Copyright (c) 2018-2025 United States Government as represented by
+ * Copyright (c) 2020-2025 United States Government as represented by
  * the U.S. Army Research Laboratory.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -293,17 +293,18 @@ void ObjectTree::updateObjectTree() {
     }
     ObjectTreeItem *rootItem = getRootItem();
     QVector<ObjectTreeItem *>& childrenOfRoot = rootItem->getChildren();
-    for (qsizetype i = 0; i != childrenOfRoot.size(); ++i) {
+    qsizetype i = 0;
+    while (i != childrenOfRoot.size()) {
         ObjectTreeItem* child = childrenOfRoot[i];
         childrenBufferPos = childrenBuffer.indexOf(child->getName());
-        // If the child already is a child of root, remove it from the childrenBuffer
-        if (childrenBufferPos != -1)
+        if (childrenBufferPos != -1) {
+            // If the child already is a child of root, remove it from the childrenBuffer
             childrenBuffer.remove(childrenBufferPos);
-        // Else, it means that the child should not be a child of root, so remove it
-        else {
+            ++i;
+        } else {
+            // Else, it means that the child should not be a child of root, so remove it
             childrenOfRoot.remove(i);
             deleteObjectTreeItem(child);
-            --i;
         }
     }
     // All the names that are that are still in childrenBuffer are new children of root, so add them

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -403,8 +403,8 @@ void ObjectTree::changeVisibilityState(size_t objectId, bool visible) {
             parentItem->setVisibilityState(ObjectTreeItem::FullyVisible);
 
             // But if there is a not FullyVisible child it should be SomeChildrenVisible
-            for (ObjectTreeItem *parentItemChild : parentItem->getChildren()){
-                if (parentItemChild->getVisibilityState() != ObjectTreeItem::FullyVisible) {
+            for (ObjectTreeItem* parentItemChild : parentItem->getChildren()) {
+                if (parentItemChild->isAlive() && parentItemChild->getVisibilityState() != ObjectTreeItem::FullyVisible) {
                     parentItem->setVisibilityState(ObjectTreeItem::SomeChildrenVisible);
                     break;
                 }
@@ -413,22 +413,23 @@ void ObjectTree::changeVisibilityState(size_t objectId, bool visible) {
         }
 
         // Then we go down in the tree and make all children FullyVisible
-        traverseSubTree(item, false, [](ObjectTreeItem *item) {
-            item->setVisibilityState(ObjectTreeItem::FullyVisible);
+        traverseSubTree(item, false, [](ObjectTreeItem* item) {
+            if (item->isAlive())
+                item->setVisibilityState(ObjectTreeItem::FullyVisible);
             return true;
         });
     } else {
         item->setVisibilityState(ObjectTreeItem::Invisible);
 
         // First we go up in the tree and make the necessary changes
-        ObjectTreeItem *parentItem = item->getParent();
+        ObjectTreeItem* parentItem = item->getParent();
         while (!parentItem->isRoot()) {
             // If all children of the ancestor are Invisible after the change ancestor's visibility should be Invisible
             parentItem->setVisibilityState(ObjectTreeItem::Invisible);
 
             // But if there is a not Invisible child it should be SomeChildrenVisible
-            for (ObjectTreeItem *parentItemChild : parentItem->getChildren()){
-                if (parentItemChild->getVisibilityState() != ObjectTreeItem::Invisible) {
+            for (ObjectTreeItem* parentItemChild : parentItem->getChildren()) {
+                if (parentItemChild->isAlive() && parentItemChild->getVisibilityState() != ObjectTreeItem::Invisible) {
                     parentItem->setVisibilityState(ObjectTreeItem::SomeChildrenVisible);
                     break;
                 }
@@ -438,7 +439,8 @@ void ObjectTree::changeVisibilityState(size_t objectId, bool visible) {
 
         // Then we go down in the tree and make all children Invisible
         traverseSubTree(item, false, [](ObjectTreeItem *item) {
-            item->setVisibilityState(ObjectTreeItem::Invisible);
+            if (item->isAlive())
+                item->setVisibilityState(ObjectTreeItem::Invisible);
             return true;
         });
     }

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -311,9 +311,13 @@ void ObjectTree::updateObjectTree() {
     }
     // All the names that are that are still in childrenBuffer are new children of root, so add them
     for (childrenBufferPos = 0; childrenBufferPos < childrenBuffer.size(); ++childrenBufferPos) {
-        ObjectTreeItem *newItem = addNewObjectTreeItem(childrenBuffer.at(childrenBufferPos));
+        QString name = childrenBuffer.at(childrenBufferPos);
+        ObjectTreeItem *newItem = addNewObjectTreeItem(name);
         newItem->setParent(rootItem);
         rootItem->addChild(newItem);
+        // Get top level object and loop through his children with callback
+        BuildObjectTreeClbk callback(this);
+        database->Get(name.toUtf8().data(), callback);
     }
 
     // Loop through all items

--- a/src/ObjectTree.cpp
+++ b/src/ObjectTree.cpp
@@ -251,7 +251,7 @@ void ObjectTree::UpdateObjectTreeClbk::traverseSubTree(const BRLCAD::Combination
 
 // ---------- OBJECT TREE ----------
 
-ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database) : database(database) {
+ObjectTree::ObjectTree(BRLCAD::MemoryDatabase* database, Document* document) : database(database), document(document) {
     // Create root item and root item data (parent = nullptr, empty name, objectId = 0)
     QString rootName = "";
     ObjectTreeItemData *rootItemData = new ObjectTreeItemData(rootName);
@@ -347,11 +347,10 @@ void ObjectTree::updateObjectTree() {
     }
 
     // Temporary solution to rebuild the objectTreeWidget
-    Document* currDocument = Globals::mainWindow->getActiveDocument();
-    currDocument->getObjectTreeWidget()->build(0);
-    currDocument->getObjectTreeWidget()->refreshItemTextColors();
-    currDocument->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
-    currDocument->getViewportGrid()->forceRerenderAllViewports();
+    document->getObjectTreeWidget()->build(0);
+    document->getObjectTreeWidget()->refreshItemTextColors();
+    document->getGeometryRenderer()->refreshForVisibilityAndSolidChanges();
+    document->getViewportGrid()->forceRerenderAllViewports();
 }
 
 

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -1,7 +1,7 @@
 /*                   O B J E C T T R E E W I D G E T . C P P
  * BRL-CAD
  *
- * Copyright (c) 2018-2025 United States Government as represented by
+ * Copyright (c) 2020-2025 United States Government as represented by
  * the U.S. Army Research Laboratory.
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
@@ -43,8 +43,8 @@ ObjectTreeWidget::ObjectTreeWidget(Document* document, QWidget* parent) : docume
     ObjectTreeRowButtons *visibilityButton = new ObjectTreeRowButtons(document->getObjectTree(), this);
     setItemDelegateForColumn(0, visibilityButton);
 
-    connect(this, &QTreeWidget::currentItemChanged, this, [this](QTreeWidgetItem *current, QTreeWidgetItem *previous) {
-        selectionChanged(current->data(0, Qt::UserRole).toInt());
+    connect(this, &QTreeWidget::currentItemChanged, this, [this](QTreeWidgetItem* current, QTreeWidgetItem* previous) {
+        selectionChanged((size_t)(current->data(0, Qt::UserRole).toLongLong()));
         // Qt changes foreground color for selected items. We don't want it changed
         setStyleSheet("ObjectTreeWidget::item:selected { color: " + current->foreground(0).color().name() + ";}");
     });

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -123,6 +123,18 @@ void ObjectTreeWidget::select(QString selected) {
 }
 
 
+void ObjectTreeWidget::traverseSubTree(QTreeWidgetItem *rootOfSubTree, bool traverseRoot, const std::function<bool(QTreeWidgetItem*)>& callback) {
+	if (traverseRoot) callback(rootOfSubTree);
+    int i = 0;
+	while (i < rootOfSubTree->childCount()) {
+        QTreeWidgetItem* item = rootOfSubTree->child(i);
+        ++i;
+		if (!callback(item)) continue;
+        if (!item->childCount() == 0) traverseSubTree(item, false, callback);
+	}
+}
+
+
 void ObjectTreeWidget::refreshItemTextColors() {
     document->getObjectTree()->traverseSubTree(document->getObjectTree()->getRootItem(), false, [this](ObjectTreeItem* item) {
         if (!item->isAlive()) {

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -184,6 +184,10 @@ void ObjectTreeWidget::update() {
         QTreeWidgetItem* item = this->objectIdTreeWidgetItemMap[objTreeItemId];
         item->setDisabled(!objTreeItem->isAlive());
 
+        // If current item is disabled, clear the current item
+        if (!objTreeItem->isAlive() && item == currentItem())
+            setCurrentItem(nullptr);
+
         return true;
     });
 }

--- a/src/gui/ObjectTreeWidget.cpp
+++ b/src/gui/ObjectTreeWidget.cpp
@@ -101,6 +101,33 @@ void ObjectTreeWidget::build(const size_t objectId, QTreeWidgetItem* parent) {
 }
 
 
+void ObjectTreeWidget::destroy(const size_t objectId) {
+    QHash<size_t, QTreeWidgetItem*>::iterator it = objectIdTreeWidgetItemMap.find(objectId);
+    if (it == objectIdTreeWidgetItemMap.end())
+        return;
+
+    QTreeWidgetItem* item = it.value();
+    item->setSelected(false);
+
+    if (item == currentItem())
+        setCurrentItem(nullptr);
+
+    // If item is not top-level, remove itself from parent's children
+    QTreeWidgetItem* parent = item->parent();
+    if (parent)
+        parent->removeChild(item);
+
+    // Remove from objectIdTreeWidgetItemMap the children of the item to delete
+    traverseSubTree(item, true, [this](QTreeWidgetItem* item) {
+        size_t id = (size_t)(item->data(0, Qt::UserRole).toLongLong());
+        this->objectIdTreeWidgetItemMap.remove(id);
+        return true;
+    });
+
+    delete item;
+}
+
+
 void ObjectTreeWidget::select(QString selected) {
     QStringList regionName = selected.split("/");
     QString path = "/" + regionName[1];

--- a/src/gui/Properties.cpp
+++ b/src/gui/Properties.cpp
@@ -51,21 +51,35 @@ Properties::Properties(Document* document) : document(document), object(nullptr)
 
 
 void Properties::bindObject(const size_t objectId) {
+    if (object != nullptr) {
+        delete object;
+        object = nullptr;
+    }
+
+    if (current != nullptr) {
+        typeSpecificPropertiesArea->removeWidget(current);
+        delete current;
+        current = nullptr;
+    }
+
+    if (objectId == 0) {
+        nameWidget->clear();
+        fullPathWidget->clear();
+        return;
+    }
+
     ObjectTreeItem* item = document->getObjectTree()->getItems()[objectId];
 
-    name = item->getName();
     fullPath = item->getPath();
     fullPathWidget->setText(QString(fullPath).replace("/"," / "));
 
-    delete object;
     object = document->getDatabase()->Get(fullPath.toUtf8().data());
     QString objectType = object->Type();
 
-    delete current;
     current = new TypeSpecificProperties(document, object, objectId);
     typeSpecificPropertiesArea->addWidget(current);
 
-    QString nameType = "<font color='$Color-PropertiesObjectNameText'>" + name + "</font> ("
+    QString nameType = "<font color='$Color-PropertiesObjectNameText'>" + item->getName() + "</font> ("
                        "<font color='$Color-PropertiesObjectTypeText'>" + breakStringAtCaps(objectType) + "</font>)";
     nameWidget->setText(Globals::theme->process(nameType));
 }

--- a/src/gui/Properties.cpp
+++ b/src/gui/Properties.cpp
@@ -1,11 +1,38 @@
+/*                         P R O P E R T I E S . C P P
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file Properties.cpp */
 
-#include <include/CollapsibleWidget.h>
+
+#include "Document.h"
+#include "Globals.h"
+#include "TypeSpecificProperties.h"
+
 #include "Properties.h"
-#include <Globals.h>
-#include <iostream>
-#include "Utils.h"
 
-Properties::Properties(Document & document) : document(document), object(nullptr), current(nullptr) {
+
+Properties::Properties(Document* document) : document(document), object(nullptr), current(nullptr) {
     nameWidget = new QLabel(this);
     nameWidget->setWordWrap(true);
     nameWidget->setObjectName("properties-nameWidget");
@@ -24,26 +51,29 @@ Properties::Properties(Document & document) : document(document), object(nullptr
 
 
 void Properties::bindObject(const size_t objectId) {
-    this->fullPath = document.getObjectTree()->getItems()[objectId]->getPath();
-    this->name = fullPath.split("/").last();
+    ObjectTreeItem* item = document->getObjectTree()->getItems()[objectId];
+
+    name = item->getName();
+    fullPath = item->getPath();
     fullPathWidget->setText(QString(fullPath).replace("/"," / "));
 
     delete object;
-    object = document.getDatabase()->Get(fullPath.toUtf8().data());
-    objectType = QString(object->Type());
+    object = document->getDatabase()->Get(fullPath.toUtf8().data());
+    QString objectType = object->Type();
 
     delete current;
     current = new TypeSpecificProperties(document, object, objectId);
     typeSpecificPropertiesArea->addWidget(current);
 
-    QString nameType = "<font color='$Color-PropertiesObjectNameText'>"+name+"</font> ("
-                       "<font color='$Color-PropertiesObjectTypeText'>"+breakStringAtCaps(objectType)+"</font>)";
+    QString nameType = "<font color='$Color-PropertiesObjectNameText'>" + name + "</font> ("
+                       "<font color='$Color-PropertiesObjectTypeText'>" + breakStringAtCaps(objectType) + "</font>)";
     nameWidget->setText(Globals::theme->process(nameType));
 }
 
+
 void Properties::rewriteObjectNameAndType() {
     if (name == "") return;  // To avoid rewriting if no object is selected (meaning that properties is empty)
-    QString nameType = "<font color='$Color-PropertiesObjectNameText'>"+name+"</font> ("
-                       "<font color='$Color-PropertiesObjectTypeText'>"+breakStringAtCaps(objectType)+"</font>)";
+    QString nameType = "<font color='$Color-PropertiesObjectNameText'>" + name + "</font> ("
+                       "<font color='$Color-PropertiesObjectTypeText'>" + breakStringAtCaps(objectType) + "</font>)";
     nameWidget->setText(Globals::theme->process(nameType));
 }

--- a/src/gui/QHBoxWidget.cpp
+++ b/src/gui/QHBoxWidget.cpp
@@ -1,22 +1,54 @@
+/*                    Q H B O X W I D G E T . C P P
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file QHBoxWidget.cpp */
 
-#include <QtWidgets/QHBoxLayout>
 #include "QHBoxWidget.h"
 
-QHBoxWidget::QHBoxWidget(QWidget *parent, Qt::WindowFlags f) : QFrame(parent, f) {
+
+QHBoxWidget::QHBoxWidget(QWidget* parent, Qt::WindowFlags f) : QFrame(parent, f) {
     boxLayout = new QHBoxLayout(this);
     boxLayout->setContentsMargins(0, 0, 0, 0);
     boxLayout->setSpacing(0);
     setLayout(boxLayout);
 }
 
-QHBoxWidget::QHBoxWidget(QWidget* parent, QWidget* child):QHBoxWidget(parent)
-{
+
+QHBoxWidget::~QHBoxWidget() {
+    delete boxLayout;
+}
+
+
+QHBoxWidget::QHBoxWidget(QWidget* parent, QWidget* child):QHBoxWidget(parent) {
     addWidget(child);
 }
+
 
 QHBoxLayout *QHBoxWidget::getBoxLayout() {
     return boxLayout;
 }
+
 
 void QHBoxWidget::addWidget(QWidget* widget) {
     boxLayout->addWidget(widget);

--- a/src/gui/QHBoxWidget.cpp
+++ b/src/gui/QHBoxWidget.cpp
@@ -53,3 +53,8 @@ QHBoxLayout *QHBoxWidget::getBoxLayout() {
 void QHBoxWidget::addWidget(QWidget* widget) {
     boxLayout->addWidget(widget);
 }
+
+
+void QHBoxWidget::removeWidget(QWidget* widget) {
+    boxLayout->removeWidget(widget);
+}

--- a/src/gui/QVBoxWidget.cpp
+++ b/src/gui/QVBoxWidget.cpp
@@ -1,8 +1,33 @@
+/*                    Q V B O X W I D G E T . C P P
+ * BRL-CAD
+ *
+ * Copyright (c) 2020-2025 United States Government as represented by
+ * the U.S. Army Research Laboratory.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+/** @file QHBoxWidget.cpp */
 
-#include <QtWidgets/QVBoxLayout>
 #include "QVBoxWidget.h"
 
-QVBoxWidget::QVBoxWidget(QWidget *parent, Qt::WindowFlags f) : QFrame(parent, f) {
+
+QVBoxWidget::QVBoxWidget(QWidget* parent, Qt::WindowFlags f) : QFrame(parent, f) {
     boxLayout = new QVBoxLayout(this);
     boxLayout->setContentsMargins(0, 0, 0, 0);
     boxLayout->setSpacing(0);

--- a/src/gui/QVBoxWidget.cpp
+++ b/src/gui/QVBoxWidget.cpp
@@ -35,15 +35,27 @@ QVBoxWidget::QVBoxWidget(QWidget* parent, Qt::WindowFlags f) : QFrame(parent, f)
     setLayout(boxLayout);
 }
 
-QVBoxWidget::QVBoxWidget(QWidget* parent, QWidget* child) : QVBoxWidget(parent)
-{
+
+QVBoxWidget::~QVBoxWidget() {
+    delete boxLayout;
+}
+
+
+QVBoxWidget::QVBoxWidget(QWidget* parent, QWidget* child) : QVBoxWidget(parent) {
     addWidget(child);
 }
+
 
 QVBoxLayout *QVBoxWidget::getBoxLayout() {
     return boxLayout;
 }
 
+
 void QVBoxWidget::addWidget(QWidget* widget) {
     boxLayout->addWidget(widget);
+}
+
+
+void QVBoxWidget::removeWidget(QWidget* widget) {
+    boxLayout->removeWidget(widget);
 }

--- a/src/viewport/MoveCameraMouseAction.cpp
+++ b/src/viewport/MoveCameraMouseAction.cpp
@@ -19,6 +19,7 @@
  */
 /** @file MoveCameraMouseAction.cpp */
 
+#include <QApplication>
 #include "ViewportGrid.h"
 #include "MoveCameraMouseAction.h"
 

--- a/src/viewport/Viewport.cpp
+++ b/src/viewport/Viewport.cpp
@@ -22,6 +22,7 @@
 #include "Viewport.h"
 
 #include <iostream>
+#include <QGuiApplication>
 #include <QScreen>
 #include <QWidget>
 #include <OrthographicCamera.h>

--- a/src/viewport/ViewportManager.cpp
+++ b/src/viewport/ViewportManager.cpp
@@ -19,6 +19,7 @@
  */
 /** @file ViewportManager.cpp */
 
+#include <QGuiApplication>
 #include <QMatrix4x4>
 #include <QScreen>
 #include "ViewportManager.h"


### PR DESCRIPTION
This PR aims to do a bunch of things. In order of importance:
- fixes segmentation fault when an object is selected in `ObjectTreeWidget`
- fixes bugs related to the `ObjectTreeWidget`'s items visibility and if they should be disabled or not
- fixes bugs related to killing the currently selected `ObjectTreeWidget`'s item (in these situations now no object will be selected, and the `Properties` will be cleared)
- creates methods to destroy elements of the `ObjectTreeWidget` and update the `ObjectTreeWidget` based on the `ObjectTree`
- fixed some memory leaks that I encountered
- added copyright notice and license when they were missing