### PR TITLE
Added support for MOOSE's `ChangeType::References`

### DIFF
--- a/include/ObjectTree.h
+++ b/include/ObjectTree.h
@@ -262,6 +262,10 @@ public:
     bool isCmdBeingExecuted() {
         return cmdBeingExecuted;
     }
+
+    void queueUpdateObjectTree() {
+        isUpdateQueued = true;
+    }
 	
 private:
     BRLCAD::MemoryDatabase* database;
@@ -295,6 +299,8 @@ private:
     BRLCAD::ConstDatabase::ChangeSignalHandler databaseChangeHandlerVar = this->databaseChangeHandler;
 
     bool cmdBeingExecuted = false;
+
+    bool isUpdateQueued = false;
 
     size_t queuedSignals = 0;
 

--- a/src/gui/Console.cpp
+++ b/src/gui/Console.cpp
@@ -268,7 +268,6 @@ void Console::executeCommand(void) {
 
     // Execute command
     BRLCAD::CommandString::State parserState = parser->Parse(argv);
-    getActiveDocument()->setModified();
 
     // Signal the ObjectTree that the GED command execution has ended
     getActiveDocument()->getObjectTree()->cmdExecutionEnded();


### PR DESCRIPTION
Now the `ObjectTree` will update itself (following the execution of a GED command) only if there is an actual change in the database (reported by `ChangeType`).