### PR TITLE
Add V&V plugin with MOOSE CommandString integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,8 @@ set(arbalest_Sources
         src/plugins/vv/ui/VVDockWidget.cpp
         src/plugins/vv/ui/VVWidget.cpp
         src/plugins/vv/ui/VVTestSelectionDialog.cpp
-        src/plugins/vv/ui/VVWidget.h)
+        src/plugins/vv/ui/VVWidget.h
+        src/plugins/vv/core/VVBackendTests.cpp)
         
 
 set(arbalest_Link_Libraries
@@ -66,7 +67,8 @@ set(arbalest_Link_Libraries
 # Meta-Object Compiling
 file(GLOB_RECURSE arbalest_HEADERS_TO_MOC
 ./include/*.h
-./src/plugins/vv/ui/*.h)
+./src/plugins/vv/ui/*.h
+./src/plugins/vv/core/*.h)
 
 #file(GLOB arbalest_HEADERS_TO_MOC ./include/*)
 #file(GLOB_RECURSE arbalest_HEADERS_TO_MOC ./include/*.h)

--- a/include/Document.h
+++ b/include/Document.h
@@ -80,6 +80,10 @@ public:
     {
         return database;
     }
+    BRLCAD::MemoryDatabase* getMemoryDatabase() const
+    {
+        return database;
+    }
 
     Viewport* getViewport();
 

--- a/include/Document.h
+++ b/include/Document.h
@@ -80,7 +80,7 @@ public:
     {
         return database;
     }
-    BRLCAD::MemoryDatabase* getMemoryDatabase() const
+    BRLCAD::Database* getDatabase()
     {
         return database;
     }

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -36,6 +36,7 @@
 #include "../plugins/vv/ui/VVIssueDialog.h"
 #include "../plugins/vv/ui/VVTestSelectionDialog.h"
 #include "../src/plugins/vv/ui/VVWidget.h"
+#include "../plugins/vv/core/VVBackendTests.h"
 
 using namespace BRLCAD;
 using namespace std;
@@ -1576,7 +1577,6 @@ void MainWindow::startVVValidation()
 
         return;
     }
-    vvWidget->appendConsoleMessage("Validation completed.");
 
     auto objectTree =
         documents[activeDocumentId]
@@ -1599,132 +1599,99 @@ void MainWindow::startVVValidation()
     vvWidget->setValidationStatus("VALIDATION RUNNING");
     vvTimer->start(1000);
 }
-
 void MainWindow::processVVValidation()
 {
     static QSet<QString> validatedNames;
-
+    static int passCount = 0;
     static int warningCount = 0;
     static int errorCount = 0;
 
     if (vvCurrentIndex == 0)
     {
         validatedNames.clear();
-
         warningCount = 0;
         errorCount = 0;
-
         vvWidget->appendConsoleMessage("[INFO] Starting validation...");
     }
 
     if (!vvRunning)
         return;
 
+    if (vvCurrentIndex < vvValidationQueue.size())
+    {
+        QString objectName = vvValidationQueue[vvCurrentIndex];
+        QString trimmedName = objectName.trimmed();
+
+        if (trimmedName.isEmpty())
+        {
+            vvWidget->addIssue("ERROR", "Name Empty");
+            errorCount++;
+        }
+        if (trimmedName.contains(" ", Qt::CaseInsensitive))
+        {
+            vvWidget->addIssue("WARNING", "Spaces found in: " + trimmedName);
+            warningCount++;
+        }
+        if (trimmedName.toLower().contains("temp"))
+        {
+            vvWidget->addIssue("WARNING", "Temp Geometry: " + trimmedName);
+            warningCount++;
+        }
+
+        Document *activeDoc = getActiveDocument();
+        if (activeDoc && activeDoc->getDatabase())
+        {
+            BRLCAD::MemoryDatabase *db = activeDoc->getMemoryDatabase();
+            if (!db)
+            {
+                vvWidget->appendConsoleMessage("[ERROR] Database unavailable.");
+                vvCurrentIndex++;
+                return;
+            }
+
+            for (const QString &testName : vvTests)
+            {
+                QString mooseResult = VVBackendTests::runMooseTest(*db, testName, trimmedName);
+
+                bool isError = mooseResult.contains("ERROR", Qt::CaseInsensitive) ||
+                               mooseResult.contains("FAIL", Qt::CaseInsensitive) ||
+                               mooseResult.contains("FAILED", Qt::CaseInsensitive);
+
+                if (isError)
+                {
+                    errorCount++;
+                    vvWidget->addIssue("ERROR", testName, mooseResult, trimmedName, "");
+                    vvWidget->appendConsoleMessage("[ERROR] " + testName + ": " + mooseResult);
+                }
+                else if (mooseResult == "SKIP")
+                {
+                    vvWidget->appendConsoleMessage("[SKIP] " + testName);
+                }
+                else
+                {
+                    passCount++;
+                    vvWidget->addIssue("PASSED", testName, "No issues found", trimmedName, "");
+                    vvWidget->appendConsoleMessage("[PASSED] " + testName);
+                }
+                QCoreApplication::processEvents();
+            }
+        }
+        vvWidget->appendConsoleMessage("Checked object: " + objectName);
+        vvCurrentIndex++;
+    }
+
     if (vvCurrentIndex >= vvValidationQueue.size())
     {
         vvTimer->stop();
         vvRunning = false;
 
-        vvWidget->addIssue(
-            "INFO",
-            "Validation completed");
-
-        vvWidget->setValidationStatus("VALIDATION COMPLETE");
-
-        int passedCount =
-            validatedNames.size() - errorCount;
-
+        int passedCount = passCount;
         if (passedCount < 0)
             passedCount = 0;
-
-        vvWidget->updateSummary(
-            errorCount,
-            warningCount,
-            passedCount);
-        return;
+        vvWidget->updateSummary(errorCount, warningCount, passedCount);
+        vvWidget->setValidationStatus("VALIDATION COMPLETE");
+        vvWidget->appendConsoleMessage("[INFO] Validation Completed Successfully.");
     }
-
-    QString objectName = vvValidationQueue[vvCurrentIndex];
-
-    QString trimmedName = objectName.trimmed();
-
-    // Empty name
-    if (vvTests.contains("No Invalid Names"))
-    {
-        if (trimmedName.isEmpty())
-        {
-            vvWidget->addIssue(
-                "ERROR",
-                "Geometry has empty/invalid name");
-
-            vvWidget->appendConsoleMessage(
-                "[ERROR] Empty geometry name detected");
-
-            errorCount++;
-            vvCurrentIndex++;
-            return;
-        }
-    }
-    // Duplicate name
-    if (vvTests.contains("Duplicate Geometry Names"))
-    {
-        if (vvCurrentIndex == 0)
-        {
-            validatedNames.clear();
-        }
-
-        if (validatedNames.contains(trimmedName))
-        {
-            vvWidget->addIssue(
-                "ERROR",
-                "Duplicate geometry name detected: " + trimmedName);
-            errorCount++;
-
-            vvWidget->appendConsoleMessage("[ERROR] Duplicate geometry detected");
-        }
-        else
-        {
-            validatedNames.insert(trimmedName);
-        }
-    }
-    // Spaces warning
-    if (vvTests.contains("No Invalid Names"))
-    {
-        if (trimmedName.contains(" "))
-        {
-            vvWidget->addIssue(
-                "WARNING",
-                "Geometry name contains spaces: " + trimmedName);
-            warningCount++;
-
-            vvWidget->appendConsoleMessage("[WARNING] Geometry name contains spaces");
-        }
-    }
-    // Temporary geometry
-    if (vvTests.contains("Temporary Geometry Check"))
-    {
-        if (trimmedName.contains(
-                "temp",
-                Qt::CaseInsensitive))
-        {
-            vvWidget->addIssue(
-                "WARNING",
-                "Temporary Geometry Test",
-                "Temporary geometry found: ",
-                trimmedName, "/all/" + trimmedName);
-            warningCount++;
-
-            vvWidget->appendConsoleMessage("[WARNING] Temporary geometry detected");
-        }
-    }
-
-    vvWidget->appendConsoleMessage(
-        "Checking object: " + objectName);
-
-    vvWidget->addIssue(
-        "INFO",
-        "Validated geometry: " + objectName);
-    vvCurrentIndex++;
 }
 
 void MainWindow::stopVVValidation()

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1641,7 +1641,7 @@ void MainWindow::processVVValidation()
         Document *activeDoc = getActiveDocument();
         if (activeDoc && activeDoc->getDatabase())
         {
-            BRLCAD::MemoryDatabase *db = activeDoc->getMemoryDatabase();
+            BRLCAD::Database *db = activeDoc->getDatabase();
             if (!db)
             {
                 vvWidget->appendConsoleMessage("[ERROR] Database unavailable.");

--- a/src/gui/MainWindow.cpp
+++ b/src/gui/MainWindow.cpp
@@ -1653,25 +1653,27 @@ void MainWindow::processVVValidation()
             {
                 QString mooseResult = VVBackendTests::runMooseTest(*db, testName, trimmedName);
 
-                bool isError = mooseResult.contains("ERROR", Qt::CaseInsensitive) ||
-                               mooseResult.contains("FAIL", Qt::CaseInsensitive) ||
-                               mooseResult.contains("FAILED", Qt::CaseInsensitive);
-
-                if (isError)
+                if (mooseResult == "SKIP")
+                {
+                    vvWidget->appendConsoleMessage("[SKIP] " + testName);
+                }
+                else if (mooseResult == "No issues found (PASSED)")
+                {
+                    passCount++;
+                    vvWidget->addIssue("PASSED", testName, "No issues found", trimmedName, "");
+                    vvWidget->appendConsoleMessage("[PASSED] " + testName);
+                }
+                else if (mooseResult.startsWith("Error:", Qt::CaseInsensitive))
                 {
                     errorCount++;
                     vvWidget->addIssue("ERROR", testName, mooseResult, trimmedName, "");
                     vvWidget->appendConsoleMessage("[ERROR] " + testName + ": " + mooseResult);
                 }
-                else if (mooseResult == "SKIP")
-                {
-                    vvWidget->appendConsoleMessage("[SKIP] " + testName);
-                }
                 else
                 {
-                    passCount++;
-                    vvWidget->addIssue("PASSED", testName, "No issues found", trimmedName, "");
-                    vvWidget->appendConsoleMessage("[PASSED] " + testName);
+                    errorCount++;
+                    vvWidget->addIssue("ERROR", testName, mooseResult, trimmedName, "");
+                    vvWidget->appendConsoleMessage("[ERROR] " + testName + ": " + mooseResult);
                 }
                 QCoreApplication::processEvents();
             }

--- a/src/plugins/vv/core/VVBackendTests.cpp
+++ b/src/plugins/vv/core/VVBackendTests.cpp
@@ -1,0 +1,99 @@
+#include "VVBackendTests.h"
+#include <QDebug>
+#include <brlcad/Database/Database.h>
+#include "Document.h"
+#include <CommandString/CommandString.h>
+#include <string>
+
+QMap<QString, QMap<QString, QStringList>> VVBackendTests::getDoubleGroupedTestSuites()
+{
+    QMap<QString, QMap<QString, QStringList>> layout;
+
+    QMap<QString, QStringList> fileGroups;
+    fileGroups["lc"] = QStringList() << "No mis-matched duplicate IDs" << "Duplicate ID check";
+    fileGroups["search"] = QStringList() << "No matrices";
+    fileGroups["valid title"] = QStringList() << "Valid title" << "Duplicate Geometry Names";
+    layout["File"] = fileGroups;
+
+    QMap<QString, QStringList> generalGroups;
+    generalGroups["search"] = QStringList()
+                              << "No nested regions" << "No empty combos" << "No solids outside of regions"
+                              << "All BoTs are volume mode (should return nothing)" << "No BoTs are left hand orientation"
+                              << "All regions have material" << "All regions have LOS";
+    generalGroups["gqa"] = QStringList() << "No null region" << "Overlaps cleared to gridsize with tolerance";
+    layout["General"] = generalGroups;
+
+    return layout;
+}
+
+QString VVBackendTests::runMooseTest(BRLCAD::Database &db, const QString &testName, const QString &objectName)
+{
+    QString safeName = objectName.trimmed();
+    if (safeName.isEmpty() || safeName == "_GLOBAL" || safeName.contains(" "))
+        return "SKIP";
+
+    QString quotedName = "{" + safeName + "}";
+    QString cmdStr;
+    if (testName == "No mis-matched duplicate IDs")
+        cmdStr = "ls -c " + quotedName;
+    else if (testName == "Duplicate ID check")
+        cmdStr = "ls -d " + safeName;
+    // else if (testName == "No null region") cmdStr = "gqa -P 1 -Ao " + safeName;
+    // else if (testName == "Overlaps cleared to gridsize with tolerance") cmdStr = "gqa -P 1 -Ao -g 32mm,4mm -t 0.3mm " + safeName;
+    else if (testName == "No null region")
+        return "SKIP";
+    else if (testName == "Overlaps cleared to gridsize with tolerance")
+        return "SKIP";
+    else if (testName == "No nested regions")
+        cmdStr = "search " + safeName + " -type region -below -type region";
+    else if (testName == "No empty combos")
+        cmdStr = "search " + safeName + " -nnodes 0";
+    else if (testName == "No solids outside of regions")
+        cmdStr = "search " + safeName + " ! -below -type region -type shape";
+    else if (testName == "All BoTs are volume mode (should return nothing)")
+        cmdStr = "search " + safeName + " -type bot ! -type volume";
+    else if (testName == "No BoTs are left hand orientation")
+        cmdStr = "search " + safeName + " -type bot -param orient=lh";
+    else if (testName == "All regions have material")
+        cmdStr = "search " + safeName + " -type region ! -attr aircode ! -attr material_id";
+    else if (testName == "All regions have LOS")
+        cmdStr = "search " + safeName + " -type region ! -attr aircode ! -attr los";
+    else if (testName == "No matrices")
+        cmdStr = "search " + safeName + " ! -matrix IDN";
+    else if (testName == "Valid title")
+        cmdStr = "title";
+    else
+        return "SKIP";
+
+    QStringList parts = cmdStr.split(' ', Qt::SkipEmptyParts);
+    std::vector<std::string> stdParts;
+    for (const auto &p : parts)
+    {
+        stdParts.push_back(p.toStdString());
+    }
+
+    std::vector<const char *> argv;
+    for (const auto &part : stdParts)
+    {
+        argv.push_back(part.c_str());
+    }
+    int argc = (int)argv.size();
+    argv.push_back(nullptr);
+
+    BRLCAD::CommandString parser(db);
+    BRLCAD::CommandString::State state = parser.Parse(argv.size(), argv.data());
+
+    const char *raw = parser.Results();
+    QString result = (raw != nullptr) ? QString(raw).trimmed() : "";
+    parser.ClearResults();
+
+    if (state == BRLCAD::CommandString::State::Success)
+    {
+        if (result.isEmpty())
+        {
+            return "No issues found (PASSED)";
+        }
+        return result;
+    }
+    return "Error: " + result;
+}

--- a/src/plugins/vv/core/VVBackendTests.cpp
+++ b/src/plugins/vv/core/VVBackendTests.cpp
@@ -81,7 +81,7 @@ QString VVBackendTests::runMooseTest(BRLCAD::Database &db, const QString &testNa
     argv.push_back(nullptr);
 
     BRLCAD::CommandString parser(db);
-    BRLCAD::CommandString::State state = parser.Parse(argv.size(), argv.data());
+    BRLCAD::CommandString::State state = parser.Parse(argc, argv.data());
 
     const char *raw = parser.Results();
     QString result = (raw != nullptr) ? QString(raw).trimmed() : "";

--- a/src/plugins/vv/core/VVBackendTests.h
+++ b/src/plugins/vv/core/VVBackendTests.h
@@ -1,0 +1,18 @@
+#ifndef VVBACKENDTESTS_H
+#define VVBACKENDTESTS_H
+
+#include <QString>
+#include <QStringList>
+#include <QMap>
+
+namespace BRLCAD {
+    class Database;
+}
+
+class VVBackendTests {
+public:
+    static QMap<QString, QMap<QString, QStringList>> getDoubleGroupedTestSuites();
+    static QString runMooseTest(BRLCAD::Database& db, const QString& testName, const QString& objectName);
+};
+
+#endif // VVBACKENDTESTS_H

--- a/src/plugins/vv/ui/VVTestSelectionDialog.cpp
+++ b/src/plugins/vv/ui/VVTestSelectionDialog.cpp
@@ -1,65 +1,95 @@
 #include "VVTestSelectionDialog.h"
+#include "../core/VVBackendTests.h"
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QPushButton>
+#include <QGroupBox>
+#include <QScrollArea>
+#include <QSplitter>
+#include <QListWidget>
+#include <QStackedWidget>
 
 VVTestSelectionDialog::VVTestSelectionDialog(QWidget *parent)
     : QDialog(parent)
 {
-    setWindowTitle(
-        "Select Tests To Run");
-    resize(500, 400);
+    setWindowTitle("Select Tests To Run");
+    resize(750, 500);
 
     QVBoxLayout *mainLayout = new QVBoxLayout(this);
-    QStringList tests = {
-        "Duplicate ID Check",
-        "No Empty Combos",
-        "No Nested Regions",
-        "Temporary Geometry Check",
-        "Duplicate Geometry Names",
-        "No Invalid Names",
-        "Overlap Validation",
-        "Volume Validation"};
 
-    for (const QString &test : tests)
+    QCheckBox *selectAllBox = new QCheckBox("Select All Suites", this);
+    selectAllBox->setChecked(true);
+    selectAllBox->setStyleSheet("font-weight: bold; padding-bottom: 5px;");
+    mainLayout->addWidget(selectAllBox);
+
+    QSplitter *splitter = new QSplitter(Qt::Horizontal, this);
+    QListWidget *suiteSideList = new QListWidget(splitter);
+    QStackedWidget *containerStack = new QStackedWidget(splitter);
+
+    QMap<QString, QMap<QString, QStringList>> layoutMap = VVBackendTests::getDoubleGroupedTestSuites();
+
+    for (auto suiteIt = layoutMap.constBegin(); suiteIt != layoutMap.constEnd(); ++suiteIt)
     {
-        QCheckBox *box = new QCheckBox(test);
-        box->setChecked(true);
-        testBoxes.append(box);
-        mainLayout->addWidget(box);
+        suiteSideList->addItem(suiteIt.key());
+
+        QScrollArea *scrollArea = new QScrollArea(containerStack);
+        scrollArea->setWidgetResizable(true);
+        QWidget *scrollContent = new QWidget(scrollArea);
+        QVBoxLayout *scrollLayout = new QVBoxLayout(scrollContent);
+
+        QMap<QString, QStringList> groups = suiteIt.value();
+        for (auto groupIt = groups.constBegin(); groupIt != groups.constEnd(); ++groupIt)
+        {
+            QGroupBox *groupXml = new QGroupBox(groupIt.key().toUpper() + " Constraints", scrollContent);
+            QVBoxLayout *groupLayout = new QVBoxLayout(groupXml);
+
+            for (const QString &testName : groupIt.value())
+            {
+                QCheckBox *box = new QCheckBox(testName, groupXml);
+                box->setChecked(true);
+                testBoxes.append(box);
+                groupLayout->addWidget(box);
+            }
+            scrollLayout->addWidget(groupXml);
+        }
+        scrollLayout->addStretch();
+        scrollContent->setLayout(scrollLayout);
+        scrollArea->setWidget(scrollContent);
+        containerStack->addWidget(scrollArea);
     }
 
-    QHBoxLayout *buttonLayout = new QHBoxLayout();
+    splitter->addWidget(suiteSideList);
+    splitter->addWidget(containerStack);
+    splitter->setSizes(QList<int>() << 200 << 550);
+    mainLayout->addWidget(splitter);
 
+    connect(suiteSideList, &QListWidget::currentRowChanged, containerStack, &QStackedWidget::setCurrentIndex);
+    suiteSideList->setCurrentRow(0);
+
+    connect(selectAllBox, &QCheckBox::toggled, this, [this](bool checked) {
+        for (QCheckBox *box : testBoxes) {
+            box->setChecked(checked);
+        }
+    });
+
+    QHBoxLayout *buttonLayout = new QHBoxLayout();
     QPushButton *okButton = new QPushButton("OK");
     QPushButton *cancelButton = new QPushButton("Cancel");
-
-    connect(okButton,
-            &QPushButton::clicked,
-            this,
-            &QDialog::accept);
-
-    connect(cancelButton,
-            &QPushButton::clicked,
-            this,
-            &QDialog::reject);
+    connect(okButton, &QPushButton::clicked, this, &QDialog::accept);
+    connect(cancelButton, &QPushButton::clicked, this, &QDialog::reject);
 
     buttonLayout->addStretch();
     buttonLayout->addWidget(okButton);
     buttonLayout->addWidget(cancelButton);
-
     mainLayout->addLayout(buttonLayout);
 }
 
-QStringList
-VVTestSelectionDialog::
-    getSelectedTests() const
+QStringList VVTestSelectionDialog::getSelectedTests() const
 {
     QStringList selected;
     for (QCheckBox *box : testBoxes)
     {
-        if (box->isChecked())
-        {
-            selected.append(
-                box->text());
-        }
+        if (box->isChecked()) selected.append(box->text());
     }
     return selected;
 }

--- a/src/plugins/vv/ui/VVWidget.cpp
+++ b/src/plugins/vv/ui/VVWidget.cpp
@@ -68,6 +68,10 @@ void VVWidget::addIssue(
             0,
             QColor(255, 180, 180));
     }
+    else if (severity == "SUCCESS")
+    {
+        item->setBackground(0, QColor(180, 255, 180));
+    }
     else if (severity == "WARNING")
     {
         item->setBackground(
@@ -119,6 +123,14 @@ void VVWidget::addIssue(
         issueItem->setBackground(
             0,
             QColor(255, 230, 180));
+    }
+    if (type == "PASSED")
+    {
+        issueItem->setBackground(0, QColor(180, 255, 180));
+    }
+    else if (type == "ERROR")
+    {
+        issueItem->setBackground(0, QColor(255, 180, 180));
     }
     parentItem->addChild(issueItem);
     parentItem->setExpanded(true);
@@ -196,10 +208,12 @@ void VVWidget::showContextMenu(const QPoint &pos)
 
     if (selected == detailsAction)
     {
-        QMessageBox::information(
-            this,
-            "VV Details",
-            "Object: " + objectName + "\n\nPath: " + fullPath);
+        QTreeWidgetItem *item = issueTree->itemAt(pos);
+        if (item)
+        {
+            QString details = item->text(2);
+            QMessageBox::information(this, "Test Result Details", details);
+        }
     }
 
     if (selected == visualizeAction)


### PR DESCRIPTION
This PR adds the Geometry V&V plugin using BRLCAD::CommandString::Parse() for running validation tests on BRL-CAD geometry. The test selection dialog is updated with grouped tests using getDoubleGroupedTestSuites(). Added getMemoryDatabase() in Document.h for writable database access.